### PR TITLE
support for primary keys fields other than id

### DIFF
--- a/cart/models.py
+++ b/cart/models.py
@@ -47,7 +47,7 @@ class Item(models.Model):
 
     # product
     def get_product(self):
-        return self.content_type.get_object_for_this_type(id=self.object_id)
+        return self.content_type.get_object_for_this_type(pk=self.object_id)
 
     def set_product(self, product):
         self.content_type = ContentType.objects.get_for_model(type(product))


### PR DESCRIPTION
I've seen pk is used all over the models.py file except in get_product. This generates errors if the product has not an id field (but another primary key). The proposed patch solves the problem. 
