### PR TITLE
test: P-1 Phase 2 — re-apply against master (stacked-PR mishap)

### DIFF
--- a/docs/ROADMAP_2026_04.md
+++ b/docs/ROADMAP_2026_04.md
@@ -776,14 +776,18 @@ through v2.2.13).
 v3.0.3 (shipped 2026-04-20) → P-1 Phase 0: pytest scaffolding,
                               conftest fixtures, canonical pattern doc.
                               No behaviour change. No API change.
-v3.0.4 (this PR)            → P-1 Phase 1: migrate test_session.py to
+v3.0.4 (pending — PR #53)   → P-1 Phase 1: migrate test_session.py to
                               tests/test_session_adapters.py as the
                               reference pytest example. Delete the
                               reflection test. No behaviour change.
-v3.0.5 (patch)              → P-1 Phase 2: migrate test_signals.py,
-                              test_templatetags.py, test_performance.py
-                              (the last dropping wall-clock assertions
-                              for django_assert_num_queries).
+v3.0.5 (this PR)            → P-1 Phase 2: migrate test_signals.py,
+                              test_templatetags.py, test_performance.py.
+                              Wall-clock perf assertions replaced with
+                              django_assert_num_queries /
+                              django_assert_max_num_queries bounds
+                              (reproducible across hardware; catches
+                              N+1 regressions that wall clock can mask).
+                              No behaviour change.
 v3.0.6 (patch)              → P-1 Phase 3: replace test_integration.py
                               (MagicMock-based) with a real HTTP test
                               suite via Django's test client.

--- a/tests/README.md
+++ b/tests/README.md
@@ -258,8 +258,14 @@ The suite is partway through the overhaul described in `docs/ROADMAP_2026_04.md`
 - ✅ Phase 0: scaffolding (this document, `conftest.py`,
   `test_conftest.py`, `pyproject.toml` config) merged. Released v3.0.3.
 - ✅ Phase 1: `test_session.py` rewritten as `test_session_adapters.py`,
-  the reference pytest example.
-- ⏭ Phases 2–5: remaining files migrated and split.
+  the reference pytest example. Targets v3.0.4.
+- ✅ Phase 2: `test_signals.py`, `test_templatetags.py`,
+  `test_performance.py` migrated. Wall-clock timings replaced with
+  `django_assert_num_queries` / `django_assert_max_num_queries` bounds.
+  Targets v3.0.5.
+- ⏭ Phase 3: replace `test_integration.py` (mock-based) with a real
+  HTTP test client suite.
+- ⏭ Phases 4–5: remaining files migrated and split.
 - ⏭ Phase 6: reflection-only tests deleted.
 - ⏭ Phase 7: behavioural coverage audit, P0 regression `xfail` tests.
 - ⏭ Phase 8: `runtests.py` deleted, CI flipped to pytest-only, coverage

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,77 +1,86 @@
-"""
-Performance tests for django-cart
-=================================
+"""Performance invariants for cart operations.
 
-Tests for v2.4.0 - verifies performance characteristics of core cart operations.
-"""
+These tests assert query-count bounds, not wall-clock timings. Query
+counts are reproducible across hardware, machine load, and Python
+versions; wall clock is not. If a change regresses the query profile
+(introduces an N+1, drops ``select_related``, caches badly) the test
+fails loudly with a bounded number.
 
-import time
+The bounds are upper bounds — passing with fewer queries is fine. If a
+future change lowers the steady-state count (e.g. a batch product
+loader for ``Cart.__iter__``), tighten the bound in the same PR.
+"""
+from __future__ import annotations
+
 from decimal import Decimal
-from unittest.mock import MagicMock
 
-from django.test import TestCase
-
-from cart.cart import Cart
-from tests.test_app.models import FakeProduct
+import pytest
 
 
-def make_request(session=None):
-    """Return a minimal mock request with a dict-based session."""
-    request = MagicMock()
-    request.session = session if session is not None else {}
-    return request
+def test_add_is_query_bounded_per_item(
+    cart, product_factory, django_assert_max_num_queries
+):
+    """50 sequential ``cart.add()`` calls must stay linear in queries.
+
+    Current profile (v3.0.4) per add: ``_get_item`` SELECT, ``Item``
+    INSERT, plus two SAVEPOINT statements from the ``transaction.atomic``
+    block. Upper bound of 250 leaves ~5 queries per add of headroom —
+    tight enough to catch a regression that (say) drops the atomic block
+    in favour of multiple transactions, or adds a ``ContentType.get``
+    per call. 250 / 50 = 5 queries/add average ceiling.
+    """
+    products = [product_factory(name=f"PerfAdd{i}") for i in range(50)]
+
+    with django_assert_max_num_queries(250):
+        for p in products:
+            cart.add(p, Decimal("10.00"), quantity=1)
+
+    assert cart.count() == 50
 
 
-def make_product(name="PerfProduct", price="10.00"):
-    """Create and persist a FakeProduct instance."""
-    return FakeProduct.objects.create(name=name, price=Decimal(price))
+def test_summary_is_a_single_aggregate_query(
+    cart, product_factory, django_assert_num_queries
+):
+    """``cart.summary()`` on N items must issue exactly one aggregate query.
 
+    Regressions this test catches: computing the total in Python instead
+    of via ``Sum(F(...) * F(...))``, fetching every item row to total it
+    up, removing the cache (which would turn a second call into another
+    query but wouldn't break this test — see the cache-specific tests
+    for that).
+    """
+    for i in range(100):
+        cart.add(product_factory(name=f"PerfSum{i}"), Decimal("10.00"))
 
-class CartPerformanceTest(TestCase):
-    """Performance tests for cart operations."""
+    cart._invalidate_cache()
 
-    def test_add_single_item_performance(self):
-        """Adding 50 items should complete in under 2 seconds."""
-        request = make_request()
-        cart = Cart(request)
-
-        start = time.perf_counter()
-        for i in range(50):
-            product = make_product(f"PerfProduct{i}")
-            cart.add(product, Decimal("10.00"), quantity=1)
-        elapsed = time.perf_counter() - start
-
-        self.assertEqual(cart.count(), 50)
-        self.assertLess(elapsed, 2.0, f"Add operations took {elapsed:.2f}s")
-
-    def test_large_cart_summary_performance(self):
-        """Summary calculation on large cart should be fast."""
-        request = make_request()
-        cart = Cart(request)
-
-        for i in range(100):
-            product = make_product(f"LargeCart{i}")
-            cart.add(product, Decimal("10.00"), quantity=1)
-
-        start = time.perf_counter()
+    with django_assert_num_queries(1):
         summary = cart.summary()
-        elapsed = time.perf_counter() - start
 
-        self.assertEqual(summary, Decimal("1000.00"))
-        self.assertLess(elapsed, 0.1, f"Summary took {elapsed:.3f}s")
+    assert summary == Decimal("1000.00")
 
-    def test_iteration_performance(self):
-        """Iterating over cart items should be efficient."""
-        request = make_request()
-        cart = Cart(request)
 
-        for i in range(50):
-            product = make_product(f"IterProduct{i}")
-            cart.add(product, Decimal("10.00"), quantity=1)
+def test_iteration_is_query_bounded_independent_of_item_count(
+    cart, product_factory, django_assert_max_num_queries
+):
+    """Iterating over all items must be O(1) queries, not O(N).
 
-        start = time.perf_counter()
+    Current profile (v3.0.4): ``Cart.__iter__`` issues a single
+    ``select_related('content_type')`` SELECT for the full item set.
+    ``list(cart)`` additionally triggers ``Cart.__len__`` (CPython asks
+    ``__len__`` for a pre-allocation hint), which invokes ``count()`` —
+    one aggregate query. So ``list(cart)`` = 2 queries regardless of
+    item count.
+
+    The upper bound of 3 catches any N+1 regression (e.g. dropping
+    ``select_related`` on ``__iter__``, or someone adding a per-item
+    ``Item.product`` fetch inside the iteration path). If a future
+    batch-loader lowers the count, tighten this bound in the same PR.
+    """
+    for i in range(50):
+        cart.add(product_factory(name=f"PerfIter{i}"), Decimal("10.00"))
+
+    with django_assert_max_num_queries(3):
         items = list(cart)
-        elapsed = time.perf_counter() - start
 
-        self.assertEqual(len(items), 50)
-        self.assertLess(elapsed, 0.5, f"Iteration took {elapsed:.3f}s")
+    assert len(items) == 50

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,166 +1,157 @@
+"""Django signals emitted by cart operations.
+
+Covers the five signals declared in cart.signals:
+    cart_item_added, cart_item_removed, cart_item_updated,
+    cart_checked_out, cart_cleared.
 """
-Tests for Django signals in cart operations.
-"""
+from __future__ import annotations
 
 from decimal import Decimal
 
-from django.test import TestCase, RequestFactory
+import pytest
 
 from cart.cart import Cart
-from cart.models import Cart as CartModel
 from cart.signals import (
+    cart_checked_out,
+    cart_cleared,
     cart_item_added,
     cart_item_removed,
     cart_item_updated,
-    cart_checked_out,
-    cart_cleared,
 )
-from tests.test_app.models import FakeProduct
 
 
-class SignalTestMixin:
-    """Mixin providing signal handler setup/teardown."""
+@pytest.fixture
+def signal_sink():
+    """Capture cart signal emissions for test inspection.
 
-    def setUp(self):
-        super().setUp()
-        self.factory = RequestFactory()
-        self.request = self.factory.get("/")
-        self.request.session = {}
-        self.signal_handlers = {
-            "added": [],
-            "removed": [],
-            "updated": [],
-            "checked_out": [],
-            "cleared": [],
-        }
-        self._connect_handlers()
+    Yields a dict with one list per signal name (``added``, ``removed``,
+    ``updated``, ``checked_out``, ``cleared``). Each handler appends a
+    record of the kwargs it was invoked with. Handlers are connected on
+    setup and disconnected on teardown automatically.
 
-    def _connect_handlers(self):
-        cart_item_added.connect(self._handle_added, sender=Cart)
-        cart_item_removed.connect(self._handle_removed, sender=Cart)
-        cart_item_updated.connect(self._handle_updated, sender=Cart)
-        cart_checked_out.connect(self._handle_checked_out, sender=Cart)
-        cart_cleared.connect(self._handle_cleared, sender=Cart)
+    Example::
 
-    def _handle_added(self, sender, cart, item, **kwargs):
-        self.signal_handlers["added"].append({"cart": cart, "item": item})
+        def test_add_emits(cart, product, signal_sink):
+            cart.add(product, Decimal("5.00"))
+            assert len(signal_sink["added"]) == 1
+    """
+    captured = {
+        "added": [],
+        "removed": [],
+        "updated": [],
+        "checked_out": [],
+        "cleared": [],
+    }
 
-    def _handle_removed(self, sender, cart, product, **kwargs):
-        self.signal_handlers["removed"].append({"cart": cart, "product": product})
+    def on_added(sender, cart, item, **kwargs):
+        captured["added"].append({"cart": cart, "item": item})
 
-    def _handle_updated(self, sender, cart, item, **kwargs):
-        self.signal_handlers["updated"].append({
+    def on_removed(sender, cart, product, **kwargs):
+        captured["removed"].append({"cart": cart, "product": product})
+
+    def on_updated(sender, cart, item, **kwargs):
+        captured["updated"].append({
             "cart": cart,
             "item": item,
-            "deleted": kwargs.get("deleted", False)
+            "deleted": kwargs.get("deleted", False),
         })
 
-    def _handle_checked_out(self, sender, cart, **kwargs):
-        self.signal_handlers["checked_out"].append({"cart": cart})
+    def on_checked_out(sender, cart, **kwargs):
+        captured["checked_out"].append({"cart": cart})
 
-    def _handle_cleared(self, sender, cart, **kwargs):
-        self.signal_handlers["cleared"].append({"cart": cart})
+    def on_cleared(sender, cart, **kwargs):
+        captured["cleared"].append({"cart": cart})
 
-    def tearDown(self):
-        cart_item_added.disconnect(self._handle_added, sender=Cart)
-        cart_item_removed.disconnect(self._handle_removed, sender=Cart)
-        cart_item_updated.disconnect(self._handle_updated, sender=Cart)
-        cart_checked_out.disconnect(self._handle_checked_out, sender=Cart)
-        cart_cleared.disconnect(self._handle_cleared, sender=Cart)
-        super().tearDown()
+    cart_item_added.connect(on_added, sender=Cart)
+    cart_item_removed.connect(on_removed, sender=Cart)
+    cart_item_updated.connect(on_updated, sender=Cart)
+    cart_checked_out.connect(on_checked_out, sender=Cart)
+    cart_cleared.connect(on_cleared, sender=Cart)
 
+    yield captured
 
-class CartItemAddedSignalTest(SignalTestMixin, TestCase):
-    """Tests for cart_item_added signal."""
-
-    def test_signal_emitted_on_add(self):
-        """Signal should be emitted when adding a product."""
-        product = FakeProduct.objects.create(name="Test Product", price=Decimal("9.99"))
-
-        cart = Cart(self.request)
-        item = cart.add(product, unit_price=Decimal("9.99"), quantity=2)
-
-        self.assertEqual(len(self.signal_handlers["added"]), 1)
-        self.assertEqual(self.signal_handlers["added"][0]["cart"], cart.cart)
-        self.assertEqual(self.signal_handlers["added"][0]["item"], item)
-
-    def test_signal_emitted_on_existing_item(self):
-        """Signal should be emitted when adding to existing item."""
-        product = FakeProduct.objects.create(name="Test Product", price=Decimal("9.99"))
-
-        cart = Cart(self.request)
-        cart.add(product, unit_price=Decimal("9.99"), quantity=2)
-        cart.add(product, unit_price=Decimal("9.99"), quantity=1)
-
-        self.assertEqual(len(self.signal_handlers["added"]), 2)
+    cart_item_added.disconnect(on_added, sender=Cart)
+    cart_item_removed.disconnect(on_removed, sender=Cart)
+    cart_item_updated.disconnect(on_updated, sender=Cart)
+    cart_checked_out.disconnect(on_checked_out, sender=Cart)
+    cart_cleared.disconnect(on_cleared, sender=Cart)
 
 
-class CartItemRemovedSignalTest(SignalTestMixin, TestCase):
-    """Tests for cart_item_removed signal."""
+# --------------------------------------------------------------------------- #
+# cart_item_added
+# --------------------------------------------------------------------------- #
 
-    def test_signal_emitted_on_remove(self):
-        """Signal should be emitted when removing a product."""
-        product = FakeProduct.objects.create(name="Test Product", price=Decimal("9.99"))
+def test_cart_item_added_fires_on_add(cart, product, signal_sink):
+    item = cart.add(product, unit_price=Decimal("9.99"), quantity=2)
 
-        cart = Cart(self.request)
-        cart.add(product, unit_price=Decimal("9.99"), quantity=2)
-        cart.remove(product)
-
-        self.assertEqual(len(self.signal_handlers["removed"]), 1)
-        self.assertEqual(self.signal_handlers["removed"][0]["cart"], cart.cart)
-        self.assertEqual(self.signal_handlers["removed"][0]["product"], product)
+    assert len(signal_sink["added"]) == 1
+    assert signal_sink["added"][0]["cart"] == cart.cart
+    assert signal_sink["added"][0]["item"] == item
 
 
-class CartItemUpdatedSignalTest(SignalTestMixin, TestCase):
-    """Tests for cart_item_updated signal."""
+def test_cart_item_added_fires_again_on_repeat_add(cart, product, signal_sink):
+    cart.add(product, unit_price=Decimal("9.99"), quantity=2)
+    cart.add(product, unit_price=Decimal("9.99"), quantity=1)
 
-    def test_signal_emitted_on_update(self):
-        """Signal should be emitted when updating an item."""
-        product = FakeProduct.objects.create(name="Test Product", price=Decimal("9.99"))
-
-        cart = Cart(self.request)
-        cart.add(product, unit_price=Decimal("9.99"), quantity=2)
-        cart.update(product, quantity=5, unit_price=Decimal("11.99"))
-
-        self.assertEqual(len(self.signal_handlers["updated"]), 1)
-        self.assertEqual(self.signal_handlers["updated"][0]["cart"], cart.cart)
-        self.assertFalse(self.signal_handlers["updated"][0]["deleted"])
-
-    def test_signal_emitted_on_update_to_zero(self):
-        """Signal should be emitted when updating quantity to 0."""
-        product = FakeProduct.objects.create(name="Test Product", price=Decimal("9.99"))
-
-        cart = Cart(self.request)
-        cart.add(product, unit_price=Decimal("9.99"), quantity=2)
-        cart.update(product, quantity=0)
-
-        self.assertEqual(len(self.signal_handlers["updated"]), 1)
-        self.assertEqual(self.signal_handlers["updated"][0]["cart"], cart.cart)
-        self.assertTrue(self.signal_handlers["updated"][0]["deleted"])
+    assert len(signal_sink["added"]) == 2
 
 
-class CartCheckedOutSignalTest(SignalTestMixin, TestCase):
-    """Tests for cart_checked_out signal."""
+# --------------------------------------------------------------------------- #
+# cart_item_removed
+# --------------------------------------------------------------------------- #
 
-    def test_signal_emitted_on_checkout(self):
-        """Signal should be emitted when checking out."""
-        cart = Cart(self.request)
-        cart.checkout()
+def test_cart_item_removed_fires_on_remove(cart, product, signal_sink):
+    cart.add(product, unit_price=Decimal("9.99"), quantity=2)
 
-        self.assertEqual(len(self.signal_handlers["checked_out"]), 1)
-        self.assertEqual(self.signal_handlers["checked_out"][0]["cart"], cart.cart)
+    cart.remove(product)
+
+    assert len(signal_sink["removed"]) == 1
+    assert signal_sink["removed"][0]["cart"] == cart.cart
+    assert signal_sink["removed"][0]["product"] == product
 
 
-class CartClearedSignalTest(SignalTestMixin, TestCase):
-    """Tests for cart_cleared signal."""
+# --------------------------------------------------------------------------- #
+# cart_item_updated
+# --------------------------------------------------------------------------- #
 
-    def test_signal_emitted_on_clear(self):
-        """Signal should be emitted when clearing the cart."""
-        product = FakeProduct.objects.create(name="Test Product", price=Decimal("9.99"))
+def test_cart_item_updated_fires_on_update(cart, product, signal_sink):
+    cart.add(product, unit_price=Decimal("9.99"), quantity=2)
 
-        cart = Cart(self.request)
-        cart.add(product, unit_price=Decimal("9.99"), quantity=2)
-        cart.clear()
+    cart.update(product, quantity=5, unit_price=Decimal("11.99"))
 
-        self.assertEqual(len(self.signal_handlers["cleared"]), 1)
-        self.assertEqual(self.signal_handlers["cleared"][0]["cart"], cart.cart)
+    assert len(signal_sink["updated"]) == 1
+    assert signal_sink["updated"][0]["cart"] == cart.cart
+    assert signal_sink["updated"][0]["deleted"] is False
+
+
+def test_cart_item_updated_carries_deleted_flag_on_zero_quantity(cart, product, signal_sink):
+    cart.add(product, unit_price=Decimal("9.99"), quantity=2)
+
+    cart.update(product, quantity=0)
+
+    assert len(signal_sink["updated"]) == 1
+    assert signal_sink["updated"][0]["deleted"] is True
+
+
+# --------------------------------------------------------------------------- #
+# cart_checked_out
+# --------------------------------------------------------------------------- #
+
+def test_cart_checked_out_fires_on_checkout(cart, signal_sink):
+    cart.checkout()
+
+    assert len(signal_sink["checked_out"]) == 1
+    assert signal_sink["checked_out"][0]["cart"] == cart.cart
+
+
+# --------------------------------------------------------------------------- #
+# cart_cleared
+# --------------------------------------------------------------------------- #
+
+def test_cart_cleared_fires_on_clear(cart, product, signal_sink):
+    cart.add(product, unit_price=Decimal("9.99"), quantity=2)
+
+    cart.clear()
+
+    assert len(signal_sink["cleared"]) == 1
+    assert signal_sink["cleared"][0]["cart"] == cart.cart

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,142 +1,123 @@
+"""Template tags declared in cart.templatetags.cart_tags.
+
+Covers the four tags: cart_item_count, cart_summary, cart_is_empty,
+cart_link.
+
+NOTE: these tests invoke the tag callables directly rather than rendering
+real templates via ``Template(...).render(...)``. The direct-call path
+exercises the function body but skips template-engine concerns (``{% load
+%}`` resolution, ``takes_context=True`` wiring, parse-time argument
+handling). End-to-end template-render coverage is owned by P0-5 (README
+template-tag examples wrong) and will be added in v3.0.16 alongside the
+README fix — see docs/ROADMAP_2026_04.md.
 """
-Tests for template tags.
-"""
+from __future__ import annotations
 
 from decimal import Decimal
 
-from django.test import TestCase, RequestFactory
+import pytest
 from django.template import Context
 
-from cart.cart import Cart
 from cart.templatetags.cart_tags import (
-    cart_item_count,
-    cart_summary,
     cart_is_empty,
+    cart_item_count,
     cart_link,
+    cart_summary,
 )
-from tests.test_app.models import FakeProduct
 
 
-class TemplateTagTestMixin:
-    """Mixin providing common setup for template tag tests."""
-
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.request = self.factory.get("/")
-        self.request.session = {}
-
-    def make_context(self, **extra):
-        """Create a template context with request."""
-        context = {"request": self.request}
-        context.update(extra)
-        return Context(context)
+@pytest.fixture
+def context_with_request(rf_request):
+    """Template context with ``rf_request`` attached — what ``takes_context=True`` sees."""
+    return Context({"request": rf_request})
 
 
-class CartItemCountTagTest(TemplateTagTestMixin, TestCase):
-    """Tests for cart_item_count template tag."""
-
-    def test_returns_zero_for_empty_cart(self):
-        """Returns 0 for empty cart."""
-        context = self.make_context()
-        result = cart_item_count(context)
-        self.assertEqual(result, 0)
-
-    def test_returns_correct_count(self):
-        """Returns correct item count."""
-        product = FakeProduct.objects.create(name="Test Product", price=Decimal("9.99"))
-
-        cart = Cart(self.request)
-        cart.add(product, unit_price=Decimal("9.99"), quantity=3)
-
-        context = self.make_context()
-        result = cart_item_count(context)
-        self.assertEqual(result, 3)
-
-    def test_returns_zero_without_request(self):
-        """Returns 0 when request not in context."""
-        context = Context({})
-        result = cart_item_count(context)
-        self.assertEqual(result, 0)
+@pytest.fixture
+def context_without_request():
+    """Template context with no request — simulates tag use outside a request cycle."""
+    return Context({})
 
 
-class CartSummaryTagTest(TemplateTagTestMixin, TestCase):
-    """Tests for cart_summary template tag."""
+# --------------------------------------------------------------------------- #
+# cart_item_count
+# --------------------------------------------------------------------------- #
 
-    def test_returns_zero_for_empty_cart(self):
-        """Returns $0.00 for empty cart."""
-        context = self.make_context()
-        result = cart_summary(context)
-        self.assertEqual(result, "$0.00")
-
-    def test_returns_formatted_total(self):
-        """Returns formatted cart total."""
-        product = FakeProduct.objects.create(name="Test Product", price=Decimal("9.99"))
-
-        cart = Cart(self.request)
-        cart.add(product, unit_price=Decimal("9.99"), quantity=2)
-
-        context = self.make_context()
-        result = cart_summary(context)
-        self.assertEqual(result, "$19.98")
-
-    def test_returns_zero_without_request(self):
-        """Returns $0.00 when request not in context."""
-        context = Context({})
-        result = cart_summary(context)
-        self.assertEqual(result, "$0.00")
+def test_cart_item_count_returns_zero_for_empty_cart(db, context_with_request):
+    assert cart_item_count(context_with_request) == 0
 
 
-class CartIsEmptyTagTest(TemplateTagTestMixin, TestCase):
-    """Tests for cart_is_empty template tag."""
+def test_cart_item_count_returns_actual_count(cart, product, context_with_request):
+    cart.add(product, unit_price=Decimal("9.99"), quantity=3)
 
-    def test_returns_true_for_empty_cart(self):
-        """Returns True for empty cart."""
-        context = self.make_context()
-        result = cart_is_empty(context)
-        self.assertTrue(result)
-
-    def test_returns_false_for_nonempty_cart(self):
-        """Returns False for non-empty cart."""
-        product = FakeProduct.objects.create(name="Test Product", price=Decimal("9.99"))
-
-        cart = Cart(self.request)
-        cart.add(product, unit_price=Decimal("9.99"), quantity=1)
-
-        context = self.make_context()
-        result = cart_is_empty(context)
-        self.assertFalse(result)
-
-    def test_returns_true_without_request(self):
-        """Returns True when request not in context."""
-        context = Context({})
-        result = cart_is_empty(context)
-        self.assertTrue(result)
+    assert cart_item_count(context_with_request) == 3
 
 
-class CartLinkTagTest(TemplateTagTestMixin, TestCase):
-    """Tests for cart_link template tag."""
+def test_cart_item_count_returns_zero_when_context_has_no_request(context_without_request):
+    assert cart_item_count(context_without_request) == 0
 
-    def test_returns_basic_link(self):
-        """Returns basic link without class."""
-        context = self.make_context()
-        result = cart_link(context)
-        self.assertIn('<a href="/cart/', result)
-        self.assertIn(">View Cart</a>", result)
 
-    def test_returns_link_with_custom_text(self):
-        """Returns link with custom text."""
-        context = self.make_context()
-        result = cart_link(context, text="Go to Cart")
-        self.assertIn(">Go to Cart</a>", result)
+# --------------------------------------------------------------------------- #
+# cart_summary
+# --------------------------------------------------------------------------- #
 
-    def test_returns_link_with_css_class(self):
-        """Returns link with CSS class."""
-        context = self.make_context()
-        result = cart_link(context, text="Cart", css_class="btn btn-primary")
-        self.assertIn('class="btn btn-primary"', result)
+def test_cart_summary_returns_zero_dollars_for_empty_cart(db, context_with_request):
+    assert cart_summary(context_with_request) == "$0.00"
 
-    def test_returns_link_without_request(self):
-        """Returns link to /cart/ when no request."""
-        context = Context({})
-        result = cart_link(context)
-        self.assertIn('<a href="/cart/">View Cart</a>', result)
+
+def test_cart_summary_returns_formatted_total(cart, product, context_with_request):
+    cart.add(product, unit_price=Decimal("9.99"), quantity=2)
+
+    assert cart_summary(context_with_request) == "$19.98"
+
+
+def test_cart_summary_returns_zero_dollars_when_context_has_no_request(
+    context_without_request,
+):
+    assert cart_summary(context_without_request) == "$0.00"
+
+
+# --------------------------------------------------------------------------- #
+# cart_is_empty
+# --------------------------------------------------------------------------- #
+
+def test_cart_is_empty_returns_true_for_empty_cart(db, context_with_request):
+    assert cart_is_empty(context_with_request) is True
+
+
+def test_cart_is_empty_returns_false_for_nonempty_cart(cart, product, context_with_request):
+    cart.add(product, unit_price=Decimal("9.99"), quantity=1)
+
+    assert cart_is_empty(context_with_request) is False
+
+
+def test_cart_is_empty_returns_true_when_context_has_no_request(context_without_request):
+    assert cart_is_empty(context_without_request) is True
+
+
+# --------------------------------------------------------------------------- #
+# cart_link
+# --------------------------------------------------------------------------- #
+
+def test_cart_link_returns_default_anchor(db, context_with_request):
+    result = cart_link(context_with_request)
+
+    assert '<a href="/cart/' in result
+    assert '>View Cart</a>' in result
+
+
+def test_cart_link_accepts_custom_text(db, context_with_request):
+    result = cart_link(context_with_request, text="Go to Cart")
+
+    assert '>Go to Cart</a>' in result
+
+
+def test_cart_link_accepts_css_class(db, context_with_request):
+    result = cart_link(context_with_request, text="Cart", css_class="btn btn-primary")
+
+    assert 'class="btn btn-primary"' in result
+
+
+def test_cart_link_falls_back_to_root_when_context_has_no_request(context_without_request):
+    result = cart_link(context_without_request)
+
+    assert '<a href="/cart/">View Cart</a>' in result


### PR DESCRIPTION
## Context

PR #54 was opened against \`test-overhaul-phase-1-session-adapters\` (stacked on PR #53) and was merged at 2026-04-21 01:24 UTC — **but into the Phase 1 branch, not into master**. When PR #53 squash-landed on master, Phase 2's content didn't cascade; it stayed sitting on the Phase 1 branch.

This PR re-applies Phase 2 directly to master. The single commit is cherry-picked from \`aec11e244f0c\` (PR #54's squash merge) and is byte-identical to what was approved in that review — no new content, no changes of intent.

## What this PR changes

- \`tests/test_signals.py\` — converted to pytest functions with the \`signal_sink\` fixture; 7 behavioural tests preserved 1:1.
- \`tests/test_templatetags.py\` — converted to pytest functions with \`context_with_request\` / \`context_without_request\` fixtures; 13 tests preserved 1:1.
- \`tests/test_performance.py\` — rewritten with \`django_assert_num_queries\` / \`django_assert_max_num_queries\` replacing wall-clock assertions; 3 tests preserved 1:1.
- \`tests/README.md\` — Phase 2 marked ✅.
- \`docs/ROADMAP_2026_04.md\` — release sequencing updated (v3.0.4 pending, v3.0.5 = this PR).

## Verification

\`\`\`
uv run pytest → 305 passed in 11.12s
\`\`\`

Identical test count and coverage to the original PR #54 review.

## Lesson learned

Stacked PRs on GitHub don't auto-cascade through squash merges. For the remaining overhaul phases I'll branch each one directly off master and accept minor README/ROADMAP conflicts on rebase, rather than stacking.

## Test plan

- [ ] CI green.
- [ ] No new content vs. PR #54 — just the re-application against the correct base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)