### PR TITLE
test: P-1 Phases 6+7 — audit + xfail regression tests for P0s

### DIFF
--- a/docs/ROADMAP_2026_04.md
+++ b/docs/ROADMAP_2026_04.md
@@ -822,7 +822,7 @@ v3.0.7 (shipped 2026-04-21) → P-1 Phase 4: split test_v300.py into
                               reflection. Custom* calculator test
                               doubles moved into the file that
                               references them. No cart behaviour change.
-v3.0.8 (this PR)            → P-1 Phase 5: split test_cart.py (the big
+v3.0.8 (shipped 2026-04-21) → P-1 Phase 5: split test_cart.py (the big
                               one — 49 TestCase subclasses, 2200 lines,
                               175 active tests + 2 silently shadowed).
                               19 new focused pytest files, one concern
@@ -861,28 +861,62 @@ v3.0.8 (patch)              → P-1 Phase 5: migrate test_cart.py (~2200
                               lines, 177 tests). May land as a series
                               of PRs per split file, each green, under
                               the 3.0.8 umbrella tag.
-v3.0.9 (patch)              → P-1 Phase 6: deletion pass — remove all
-                              reflection-only tests per the explicit
-                              list in §P-1.
-v3.0.10 (patch)             → P-1 Phase 7: behavioural coverage audit;
-                              author @pytest.mark.xfail(strict=True)
-                              regression tests for each known P0 bug.
-v3.0.11 (patch)             → P-1 Phase 8: unify test runner, delete
+v3.0.9 (this PR)            → P-1 Phases 6 + 7 combined: Phase 6's
+                              reflection-test deletion pass was done
+                              inline across Phases 1–5 and left
+                              nothing of substance to remove, so it's
+                              folded into Phase 7 rather than shipped
+                              as its own patch. Phase 7 content:
+                              - Four @pytest.mark.xfail(strict=True)
+                                regression tests covering the known
+                                P0 bugs (P0-1 from_serializable silent
+                                no-op, P0-2 Discount.current_uses
+                                never increments, P0-3
+                                CARTS_SESSION_ADAPTER_CLASS ignored,
+                                P0-4 CookieSessionAdapter no HTTP
+                                round-trip).
+                              - Coverage fills for the remaining
+                                uncovered behaviour branches:
+                                Cart.merge max-quantity caps (two
+                                paths), Cart.add_bulk invalid-quantity
+                                rollback, misconfigured calculator/
+                                checker fallbacks (tax/shipping/
+                                inventory), can_checkout minimum-met
+                                branch, Discount.increment_usage
+                                direct call, CookieSessionAdapter
+                                without response, cookie-delete of
+                                missing key.
+                              - Positive template-render tests via
+                                Template().render() for each cart
+                                template tag (the P0-5 fix is doc-only
+                                and needs no xfail; locking in the
+                                correct syntax guards against future
+                                README drift).
+                              Suite: 263 → 278 passed + 4 xfailed.
+                              Coverage: 95% → 98%. Remaining 2% is
+                              intentional dead code (cart/cart.py
+                              signals-ImportError fallback, retired
+                              in P1-11) and an orphan admin method
+                              (cart/admin.py:11 — admin-config bug
+                              tracked separately).
+v3.0.10 (patch)             → P-1 Phase 8: unify test runner, delete
                               runtests.py, tighten pytest config
                               (python_classes=[], filterwarnings=error),
                               enable coverage --fail-under=100 in CI.
                               P-1 complete.
-v3.0.12 .. v3.0.18 (patch)  → P0 bug fixes, one per release, each
+v3.0.11 .. v3.0.17 (patch)  → P0 bug fixes, one per release, each
                               removing an @xfail marker as the fix:
-                              3.0.12 = P0-1 (from_serializable)
-                              3.0.13 = P0-2 (discount current_uses —
+                              3.0.11 = P0-1 (from_serializable)
+                              3.0.12 = P0-2 (discount current_uses —
                                       gated, see note below)
-                              3.0.14 = P0-3 (CARTS_SESSION_ADAPTER_CLASS)
-                              3.0.15 = P0-4 (CookieSessionAdapter
+                              3.0.13 = P0-3 (CARTS_SESSION_ADAPTER_CLASS)
+                              3.0.14 = P0-4 (CookieSessionAdapter
                                       round-trip)
-                              3.0.16 = P0-5 (README template-tag fix)
-                              3.0.17 = P0-6 (CHANGELOG backfill)
-                              3.0.18 = P0-7 (docs stale-banner)
+                              3.0.15 = P0-5 (README template-tag
+                                      examples — doc-only fix, no
+                                      xfail to remove)
+                              3.0.16 = P0-6 (CHANGELOG backfill)
+                              3.0.17 = P0-7 (docs stale-banner)
 v3.1.0 (minor)              → P1 block + P2-1, P2-2, P2-3, P2-9.
                               Cart.checkout() grows a validate kwarg.
                               Default is None → DeprecationWarning +

--- a/tests/README.md
+++ b/tests/README.md
@@ -287,8 +287,18 @@ The suite is partway through the overhaul described in `docs/ROADMAP_2026_04.md`
   replacement for the legacy config-reflection classes),
   `test_cart_atomic.py`, `test_clean_carts_command.py`. The two
   shadowed tests from the duplicate `CartIterationTest` class are
-  recovered (P1-5 dissolves). Targets v3.0.8.
-- ⏭ Phase 6: reflection-only tests deleted.
+  recovered (P1-5 dissolves). Shipped in v3.0.8.
+- ✅ Phases 6+7 (combined): behavioural coverage audit + remaining
+  reflection sweep. Four `@pytest.mark.xfail(strict=True)` regression
+  tests added for known P0 bugs (P0-1 `from_serializable`, P0-2
+  `Discount.current_uses`, P0-3 `CARTS_SESSION_ADAPTER_CLASS`, P0-4
+  `CookieSessionAdapter` round-trip). Coverage fills added for
+  merge max-quantity cap paths, `add_bulk` rollback on invalid-quantity,
+  misconfigured calculator/checker fallbacks, `can_checkout` minimum-
+  met branch. Positive template-render tests via Django's template
+  engine for the four cart template tags (doc-fix for P0-5 needs no
+  xfail — behaviour is correct today). Coverage: 95% → 98%. Targets
+  v3.0.9.
 - ⏭ Phase 6: reflection-only tests deleted.
 - ⏭ Phase 7: behavioural coverage audit, P0 regression `xfail` tests.
 - ⏭ Phase 8: `runtests.py` deleted, CI flipped to pytest-only, coverage

--- a/tests/test_cart_bulk.py
+++ b/tests/test_cart_bulk.py
@@ -49,3 +49,22 @@ def test_add_bulk_returns_list_of_item_instances(cart, product_factory):
     assert isinstance(result, list)
     assert len(result) == 1
     assert result[0].quantity == 2
+
+
+def test_add_bulk_raises_on_invalid_quantity_and_rolls_back_earlier_items(cart, product_factory):
+    """Mid-batch invalid quantity aborts the whole operation atomically.
+    Covers cart/cart.py:441 (the `quantity < 1` guard inside add_bulk)."""
+    from cart.cart import InvalidQuantity
+
+    good1 = product_factory(name="BulkGood1")
+    good2 = product_factory(name="BulkGood2")
+    items = [
+        {"product": good1, "unit_price": Decimal("10.00"), "quantity": 1},
+        {"product": good2, "unit_price": Decimal("10.00"), "quantity": 0},  # invalid
+    ]
+
+    with pytest.raises(InvalidQuantity):
+        cart.add_bulk(items)
+
+    # Atomic rollback: neither item should have been saved.
+    assert cart.is_empty() is True

--- a/tests/test_cart_checkout.py
+++ b/tests/test_cart_checkout.py
@@ -41,6 +41,19 @@ def test_can_checkout_rejects_cart_below_min_order_amount_setting(cart, product,
     assert "500.00" in message
 
 
+def test_can_checkout_accepts_cart_at_or_above_min_order_amount(cart, product, settings):
+    """Covers the `min_amount is not None AND summary >= min_amount`
+    branch in can_checkout — previously unreachable through the suite
+    (only the below-minimum path was exercised)."""
+    settings.CART_MIN_ORDER_AMOUNT = Decimal("100.00")
+    cart.add(product, unit_price=Decimal("100.00"), quantity=2)
+
+    can_checkout, message = cart.can_checkout()
+
+    assert can_checkout is True
+    assert message == ""
+
+
 # --------------------------------------------------------------------------- #
 # checkout() — marks the DB record
 # --------------------------------------------------------------------------- #

--- a/tests/test_cart_discounts.py
+++ b/tests/test_cart_discounts.py
@@ -108,3 +108,45 @@ def test_applying_discount_invalidates_cart_cache(cart_worth_200):
     cart_worth_200.apply_discount("CACHE_TEST")
 
     assert cart_worth_200.discount_amount() == Decimal("20.00")
+
+
+# --------------------------------------------------------------------------- #
+# Discount.increment_usage — direct coverage of the model method
+# --------------------------------------------------------------------------- #
+
+def test_discount_increment_usage_increments_the_counter(discount_percent):
+    """The method exists on Discount but is never called from Cart today
+    (P0-2). Tested directly so the model-level behaviour is covered
+    regardless of whether the Cart integration lands."""
+    starting = discount_percent.current_uses
+
+    discount_percent.increment_usage()
+
+    discount_percent.refresh_from_db()
+    assert discount_percent.current_uses == starting + 1
+
+
+# --------------------------------------------------------------------------- #
+# P0 regression — @xfail until the fix lands
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "P0-2 — Discount.current_uses is never incremented automatically. "
+        "apply_discount() + checkout() leaves the counter at 0 regardless "
+        "of max_uses, so usage limits are not enforced in practice. "
+        "Scheduled for v3.0.12 (see docs/ROADMAP_2026_04.md §P0-2)."
+    ),
+)
+def test_apply_discount_then_checkout_increments_current_uses(
+    cart_worth_200, discount_percent
+):
+    """After applying a discount and checking out, the discount's
+    current_uses should be 1. Today it stays 0."""
+    cart_worth_200.apply_discount("PERCENT20")
+
+    cart_worth_200.checkout()
+
+    discount_percent.refresh_from_db()
+    assert discount_percent.current_uses == 1

--- a/tests/test_cart_init.py
+++ b/tests/test_cart_init.py
@@ -5,9 +5,42 @@ import pytest
 from django.test import RequestFactory
 
 from cart.cart import CART_ID, Cart
+from cart.session import CartSessionAdapter
 
 
 pytestmark = pytest.mark.django_db
+
+
+class _RecordingSessionAdapter(CartSessionAdapter):
+    """Module-level test double referenced by dotted path in the
+    ``CARTS_SESSION_ADAPTER_CLASS`` setting for the P0-3 regression test.
+
+    Implemented via class-level state so the test can assert "the adapter
+    saw at least one call" without the adapter instance escaping the
+    Cart constructor.
+    """
+
+    calls: list = []
+
+    def __init__(self, request):
+        self._request = request
+
+    def get(self, key, default=None):
+        self.calls.append(("get", key))
+        return default
+
+    def set(self, key, value):
+        self.calls.append(("set", key, value))
+
+    def delete(self, key):
+        self.calls.append(("delete", key))
+
+    def get_or_create_cart_id(self):
+        self.calls.append(("get_or_create_cart_id",))
+        return None
+
+    def set_cart_id(self, cart_id):
+        self.calls.append(("set_cart_id", cart_id))
 
 
 def test_new_cart_is_created_when_session_has_no_cart_id(rf_request):
@@ -61,3 +94,31 @@ def test_shared_session_yields_same_cart_across_requests():
     c2 = Cart(r2)
 
     assert c1.cart.pk == c2.cart.pk
+
+
+# --------------------------------------------------------------------------- #
+# P0 regression — @xfail until the fix lands
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "P0-3 — CARTS_SESSION_ADAPTER_CLASS setting is documented in the "
+        "README but never read by Cart.__init__. The constructor hardcodes "
+        "request.session access. Scheduled for v3.0.13 (see "
+        "docs/ROADMAP_2026_04.md §P0-3)."
+    ),
+)
+def test_carts_session_adapter_class_setting_is_honoured(settings, rf_request):
+    """Setting the adapter class should cause Cart to route session ops
+    through it, leaving request.session untouched."""
+    settings.CARTS_SESSION_ADAPTER_CLASS = (
+        "tests.test_cart_init._RecordingSessionAdapter"
+    )
+
+    Cart(rf_request)
+
+    # Target behaviour: the adapter is used, so request.session stays clean.
+    # Current behaviour: Cart ignores the setting and writes CART-ID
+    # directly into request.session → assertion fails → xfail expected.
+    assert CART_ID not in rf_request.session

--- a/tests/test_cart_max_quantity.py
+++ b/tests/test_cart_max_quantity.py
@@ -55,3 +55,37 @@ def test_add_bulk_respects_max(cart, product_factory, settings):
         cart.add_bulk([
             {"product": product_factory(name="BulkMax"), "unit_price": Decimal("10.00"), "quantity": 10},
         ])
+
+
+# --------------------------------------------------------------------------- #
+# Merge caps combined quantity at max (unlike add, which raises, merge
+# silently clamps — the two paths are reached by cart/cart.py:373 and 381).
+# --------------------------------------------------------------------------- #
+
+def test_merge_caps_combined_quantity_when_both_carts_contain_the_same_product(
+    cart, other_cart, product, settings
+):
+    """cart/cart.py:373 — existing item path."""
+    settings.CART_MAX_QUANTITY_PER_ITEM = 10
+    cart.add(product, Decimal("10.00"), quantity=6)
+    other_cart.add(product, Decimal("10.00"), quantity=6)
+
+    cart.merge(other_cart, strategy="add")
+
+    assert cart.cart.items.first().quantity == 10
+
+
+def test_merge_caps_new_item_quantity_when_source_cart_overshoots(
+    cart, other_cart, product, settings
+):
+    """cart/cart.py:381 — new-item path (product not already in target).
+
+    Populate the source cart first (without the cap), then apply the cap
+    before merging. Otherwise the cap would block the setup-stage add.
+    """
+    other_cart.add(product, Decimal("10.00"), quantity=20)
+    settings.CART_MAX_QUANTITY_PER_ITEM = 5
+
+    cart.merge(other_cart, strategy="add")
+
+    assert cart.cart.items.first().quantity == 5

--- a/tests/test_cart_serialization.py
+++ b/tests/test_cart_serialization.py
@@ -106,3 +106,27 @@ def test_from_serializable_with_empty_data_leaves_cart_untouched(cart, product, 
     restored = Cart.from_serializable(rf_request, {})
 
     assert restored.count() == 1
+
+
+# --------------------------------------------------------------------------- #
+# P0 regression — @xfail until the fix lands
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "P0-1 — Cart.from_serializable is a silent no-op on a fresh cart. "
+        "The method only updates pre-existing items, so on an empty cart "
+        "nothing happens despite the docstring claiming 'restore a cart "
+        "from serializable data'. Scheduled for v3.0.11 (see "
+        "docs/ROADMAP_2026_04.md §P0-1)."
+    ),
+)
+def test_from_serializable_is_not_a_silent_noop_on_fresh_cart(rf_request, product):
+    """Calling from_serializable with items on a brand-new cart should
+    leave the cart populated. Today it silently returns an empty cart."""
+    data = {str(product.pk): {"quantity": 3, "unit_price": "15.00"}}
+
+    cart = Cart.from_serializable(rf_request, data)
+
+    assert not cart.is_empty()

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -70,6 +70,22 @@ def test_custom_inventory_checker_subclass_is_usable_inline():
     assert checker.check(MagicMock(), 10) is False
 
 
+def test_default_inventory_checker_reserve_returns_true():
+    """Covers cart/inventory.py — DefaultInventoryChecker.reserve."""
+    assert DefaultInventoryChecker().reserve(MagicMock(), 1) is True
+
+
+@pytest.mark.django_db
+def test_get_inventory_checker_falls_back_to_default_when_class_path_is_bad(settings):
+    """Covers cart/inventory.py:158-159 — ImportError/AttributeError
+    fallback. P1-4 adds a warning log around this."""
+    settings.CART_INVENTORY_CHECKER = "nonexistent.module.FakeChecker"
+
+    checker = get_inventory_checker()
+
+    assert isinstance(checker, DefaultInventoryChecker)
+
+
 # --------------------------------------------------------------------------- #
 # Cart.add integration (check_inventory parameter)
 # --------------------------------------------------------------------------- #

--- a/tests/test_session_adapters.py
+++ b/tests/test_session_adapters.py
@@ -148,3 +148,70 @@ def test_cookie_get_or_create_cart_id_returns_none_for_non_integer(
     cookie_adapter.cookies["CART-ID"] = bad_value
 
     assert cookie_adapter.get_or_create_cart_id() is None
+
+
+def test_cookie_set_cart_id_serialises_int_as_string(cookie_adapter):
+    """set_cart_id coerces to str so the cookie value is HTTP-transport-safe.
+    Covers cart/session.py lines 107-108 — previously dead since no test
+    called set_cart_id on the cookie adapter."""
+    cookie_adapter.set_cart_id(42)
+
+    assert cookie_adapter.cookies["CART-ID"] == "42"
+    cookie_adapter.response.set_cookie.assert_called_once_with("CART-ID", "42")
+
+
+def test_cookie_adapter_without_response_stores_in_memory_only():
+    """Without a response, set/delete still mutate the in-memory dict but
+    skip the response.set_cookie / response.delete_cookie side effects.
+    Covers the ``if self._response is not None`` branches."""
+    adapter = CookieSessionAdapter()
+
+    adapter.set("key", "value")
+    assert adapter._cookies["key"] == "value"
+
+    adapter.delete("key")
+    assert "key" not in adapter._cookies
+
+
+def test_cookie_adapter_delete_on_missing_key_is_noop():
+    """Covers the ``if key in self._cookies`` branch of delete()."""
+    adapter = CookieSessionAdapter()
+
+    adapter.delete("never-set")  # must not raise
+
+    assert "never-set" not in adapter._cookies
+
+
+# --------------------------------------------------------------------------- #
+# P0 regression — @xfail until the fix lands
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "P0-4 — CookieSessionAdapter.__init__ never populates self._cookies "
+        "from request.COOKIES, so a cart id set on one request is not "
+        "recoverable on the next. The in-memory round-trip works (previous "
+        "tests); the HTTP round-trip does not. Scheduled for v3.0.14 "
+        "(see docs/ROADMAP_2026_04.md §P0-4)."
+    ),
+)
+def test_cookie_session_adapter_round_trips_via_real_request_cookies():
+    """Two sequential requests sharing a cookie jar should see the same
+    cart id — the canonical cookie-session-adapter contract."""
+    from django.http import HttpResponse
+    from django.test import RequestFactory
+
+    # Request 1: adapter writes cart id to the response's Set-Cookie.
+    response = HttpResponse()
+    writer = CookieSessionAdapter(response=response)
+    writer.set_cart_id(42)
+
+    cart_id_cookie = response.cookies["CART-ID"].value
+
+    # Request 2: browser echoes the cookie back; Django populates
+    # request.COOKIES from it. The adapter must hydrate from that.
+    request = RequestFactory().get("/", COOKIES={"CART-ID": cart_id_cookie})
+    reader = CookieSessionAdapter(request=request)
+
+    assert reader.get_or_create_cart_id() == 42

--- a/tests/test_shipping.py
+++ b/tests/test_shipping.py
@@ -71,3 +71,14 @@ def test_custom_shipping_calculator_subclass_is_usable_inline():
     calc = InlineShipping()
     assert calc.calculate(_mock_cart()) == Decimal("5.99")
     assert len(calc.get_options(_mock_cart())) == 1
+
+
+@pytest.mark.django_db
+def test_get_shipping_calculator_falls_back_to_default_when_class_path_is_bad(settings):
+    """Covers cart/shipping.py:143-144 — ImportError/AttributeError
+    fallback. P1-4 adds a warning log around this."""
+    settings.CART_SHIPPING_CALCULATOR = "nonexistent.module.FakeShipping"
+
+    calculator = get_shipping_calculator()
+
+    assert isinstance(calculator, DefaultShippingCalculator)

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -48,3 +48,15 @@ def test_custom_tax_calculator_subclass_is_usable_inline():
             return Decimal("25.50")
 
     assert InlineTax().calculate(_mock_cart()) == Decimal("25.50")
+
+
+@pytest.mark.django_db
+def test_get_tax_calculator_falls_back_to_default_when_class_path_is_bad(settings):
+    """Covers cart/tax.py:97-98 — the ImportError/AttributeError
+    fallback. Today's behaviour (silent fallback) is locked in; P1-4
+    will add a warning log around it."""
+    settings.CART_TAX_CALCULATOR = "nonexistent.module.FakeTax"
+
+    calculator = get_tax_calculator()
+
+    assert isinstance(calculator, DefaultTaxCalculator)

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -121,3 +121,53 @@ def test_cart_link_falls_back_to_root_when_context_has_no_request(context_withou
     result = cart_link(context_without_request)
 
     assert '<a href="/cart/">View Cart</a>' in result
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end template rendering — the tags must work through Django's real
+# template engine, not just as Python callables.
+#
+# Related to P0-5: the README currently shows the tags invoked with a
+# positional ``request`` argument (`{% cart_item_count request %}`), which
+# doesn't match the ``takes_context=True`` implementation. That bug is a
+# docs-only fix (the README text gets corrected in v3.0.16); there is no
+# behavioural regression to @xfail. These tests instead lock in the
+# CORRECT tag-invocation syntax so a future README update has a test to
+# sanity-check against, and verify the templates render under Django's
+# full loader/parser/renderer.
+# --------------------------------------------------------------------------- #
+
+from django.template import Template  # noqa: E402 — logically belongs with the block below
+
+
+def test_cart_item_count_renders_through_template_engine(db, rf_request):
+    tpl = Template("{% load cart_tags %}{% cart_item_count %}")
+
+    result = tpl.render(Context({"request": rf_request}))
+
+    assert result == "0"
+
+
+def test_cart_summary_renders_through_template_engine(db, rf_request):
+    tpl = Template("{% load cart_tags %}{% cart_summary %}")
+
+    result = tpl.render(Context({"request": rf_request}))
+
+    assert result == "$0.00"
+
+
+def test_cart_is_empty_renders_through_template_engine(db, rf_request):
+    tpl = Template("{% load cart_tags %}{% cart_is_empty %}")
+
+    result = tpl.render(Context({"request": rf_request}))
+
+    assert result == "True"
+
+
+def test_cart_link_renders_through_template_engine(db, rf_request):
+    tpl = Template('{% load cart_tags %}{% cart_link "My Cart" "btn btn-primary" %}')
+
+    result = tpl.render(Context({"request": rf_request}))
+
+    assert 'class="btn btn-primary"' in result
+    assert '>My Cart</a>' in result


### PR DESCRIPTION
## Summary

Phases 6 and 7 of the P-1 test overhaul (`docs/ROADMAP_2026_04.md` §P-1), combined per maintainer direction. Phase 6's reflection-deletion pass was done inline across Phases 1–5 and had nothing of substance left; Phase 7 carries the behavioural audit and the @xfail regression tests for known P0 bugs. **No cart behaviour change.**

## New @xfail regression tests (4)

Each uses `strict=True` so an unexpected pass fails the build — the fix PR removes the marker as its first commit and the test turns green, guaranteeing a CHANGELOG entry for the behaviour change.

| xfail | Bug | File | Fix scheduled |
|---|---|---|---|
| `test_from_serializable_is_not_a_silent_noop_on_fresh_cart` | P0-1 | `test_cart_serialization.py` | v3.0.11 |
| `test_apply_discount_then_checkout_increments_current_uses` | P0-2 | `test_cart_discounts.py` | v3.0.12 |
| `test_carts_session_adapter_class_setting_is_honoured` | P0-3 | `test_cart_init.py` | v3.0.13 |
| `test_cookie_session_adapter_round_trips_via_real_request_cookies` | P0-4 | `test_session_adapters.py` | v3.0.14 |

**P0-5 (README template-tag examples)** is handled differently — it's a doc-only fix with no behavioural regression to xfail. Instead, four positive template-render tests via `Template().render()` are added. They pass today and pin the correct tag syntax so future README drift is caught.

## Coverage fills (previously uncovered branches)

- `Cart.merge` max-quantity caps on existing-item (`cart/cart.py:373`) and new-item (`cart/cart.py:381`) paths.
- `Cart.add_bulk` invalid-quantity rollback (`cart/cart.py:441`) — asserts atomic recovery.
- `get_tax_calculator` / `get_shipping_calculator` / `get_inventory_checker` misconfig fallback to default (the `ImportError`/`AttributeError` branches).
- `DefaultInventoryChecker.reserve` direct test.
- `can_checkout` minimum-met branch (both min_amount is set AND met → `(True, "")`).
- `Discount.increment_usage` direct test — lines 230-231 previously dead code.
- `CookieSessionAdapter` with `response=None`: set/delete work in-memory only; delete of missing key is a no-op.
- `CookieSessionAdapter.set_cart_id` serialises int to str.

## Verification

```
uv run pytest → 279 passed, 4 xfailed in 15.41s
```

**Coverage: 95% → 98%.**

Remaining 2% is:
- `cart/cart.py:18-23` — intentional `try/except ImportError` signals fallback. Retired by P1-11 (part of v3.1 block).
- `cart/admin.py:11` — orphan `total_price` method on `ItemInline` (the method exists but isn't listed in `readonly_fields`/`fields`, so it's never rendered). Admin-config bug, out of scope for Phase 7 — flagged for separate cleanup.
- A handful of `signal is None` branches in `cart/cart.py` that only activate when the signals module fails to import (the P1-11 deletion). They'll go away with the import guard.

## Release sequencing impact (ROADMAP updated in-PR)

| Version | Content |
|---|---|
| v3.0.9 | **This PR** — Phases 6+7 combined |
| v3.0.10 | Phase 8 — unify runner, tighten pytest config, `coverage --fail-under=100` in CI. P-1 complete. |
| v3.0.11 | P0-1 fix (remove xfail, fix from_serializable) |
| v3.0.12 | P0-2 fix |
| v3.0.13 | P0-3 fix |
| v3.0.14 | P0-4 fix |
| v3.0.15 | P0-5 fix (README) |
| v3.0.16 | P0-6 fix (CHANGELOG backfill) |
| v3.0.17 | P0-7 fix (docs banner) |
| v3.1.0 | P1 block |

## Test plan

- [ ] CI matrix green across all 18 Py×Django combinations.
- [ ] Reviewer confirms the four xfail `reason` strings accurately describe each bug and correctly cite `docs/ROADMAP_2026_04.md §P0-N`.
- [ ] Reviewer confirms the strict=True semantics: removing `@xfail` in a future PR is the trigger to flip red→green, not a behaviour-less marker-flip.
- [ ] Reviewer checks P0-5 handling is acceptable (positive tests, no xfail) vs forcing an xfail shape that doesn't fit docs-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)