### PR TITLE
fix(P0-1): Cart.from_serializable actually restores items on a fresh cart

### DIFF
--- a/cart/cart.py
+++ b/cart/cart.py
@@ -292,12 +292,25 @@ class Cart:
         Example output::
 
             {
-                "42": {"total_price": "19.98", "quantity": 2, "unit_price": "9.99"},
+                "42": {
+                    "content_type_id": 7,
+                    "total_price": "19.98",
+                    "unit_price": "9.99",
+                    "quantity": 2,
+                },
                 ...
             }
+
+        The ``content_type_id`` field was added in v3.0.11 (P0-1 fix —
+        see docs/ROADMAP_2026_04.md §P0-1). It lets
+        :meth:`from_serializable` create items in a fresh cart rather
+        than silently no-op'ing. Pre-v3.0.11 payloads (without this
+        field) can still update items already present in the target
+        cart; they cannot restore into an empty one.
         """
         return {
             str(item.object_id): {
+                "content_type_id": item.content_type_id,
                 "total_price": str(item.total_price),
                 "unit_price": str(item.unit_price),
                 "quantity": item.quantity,
@@ -310,29 +323,57 @@ class Cart:
         """
         Restore a cart from serializable data.
 
+        Creates any items whose ``object_id`` isn't already present in
+        the target cart, provided the payload supplies
+        ``content_type_id`` alongside them. Items that already exist are
+        updated in place from ``quantity`` / ``unit_price`` if given.
+
         :param request: Django request object.
         :param data: Dict as produced by :meth:`cart_serializable`.
         :returns: A :class:`Cart` instance with the restored items.
+        :raises ValueError: if the payload is missing ``content_type_id``
+            for an item that isn't already present in the target cart.
+            Pre-v3.0.11 payloads lack this field and can only update
+            pre-existing items.
 
         Example::
 
-            cart_data = {
-                "42": {"total_price": "19.98", "quantity": 2, "unit_price": "9.99"},
-            }
-            cart = Cart.from_serializable(request, cart_data)
+            serialised = cart.cart_serializable()
+            # ...later, possibly from a different request...
+            restored = Cart.from_serializable(new_request, serialised)
         """
         cart = cls(request)
-        for object_id, item_data in data.items():
-            from django.contrib.contenttypes.models import ContentType
-            item = models.Item.objects.filter(
-                cart=cart.cart,
-                object_id=object_id
-            ).first()
-            if item:
-                item.quantity = item_data.get("quantity", item.quantity)
-                if "unit_price" in item_data:
-                    item.unit_price = Decimal(item_data["unit_price"])
-                item.save()
+        with transaction.atomic():
+            for object_id, item_data in data.items():
+                item = models.Item.objects.filter(
+                    cart=cart.cart,
+                    object_id=object_id,
+                ).first()
+                if item is not None:
+                    item.quantity = item_data.get("quantity", item.quantity)
+                    if "unit_price" in item_data:
+                        item.unit_price = Decimal(item_data["unit_price"])
+                    item.save()
+                    continue
+
+                content_type_id = item_data.get("content_type_id")
+                if content_type_id is None:
+                    raise ValueError(
+                        f"Cannot restore item object_id={object_id!r}: "
+                        "payload is missing 'content_type_id'. Pre-v3.0.11 "
+                        "serialised payloads lack this field and can only "
+                        "update items already present in the cart."
+                    )
+
+                models.Item.objects.create(
+                    cart=cart.cart,
+                    content_type_id=content_type_id,
+                    object_id=int(object_id),
+                    quantity=item_data.get("quantity", 1),
+                    unit_price=Decimal(item_data.get("unit_price", "0.00")),
+                )
+
+        cart._invalidate_cache()
         return cart
 
     def merge(self, other_cart: "Cart", strategy: str = "add") -> None:

--- a/docs/ROADMAP_2026_04.md
+++ b/docs/ROADMAP_2026_04.md
@@ -942,9 +942,33 @@ v3.0.10 (this PR)           → P-1 Phase 8: runner unification.
                               behaviour change lands as "failing test
                               first, then the fix" on the pytest
                               foundation built over v3.0.3–v3.0.10.
-v3.0.11 .. v3.0.17 (patch)  → P0 bug fixes, one per release, each
-                              removing an @xfail marker as the fix:
-                              3.0.11 = P0-1 (from_serializable)
+v3.0.11 (this PR)           → P0-1 fix: Cart.from_serializable
+                              actually restores items into a fresh
+                              cart. Option 2 of the original fix menu
+                              was chosen (Option 1 — rename — was
+                              ruled out by the Phase 7 xfail test that
+                              asserts items exist post-restore). Net
+                              change:
+                              - cart_serializable() output gains a
+                                new `content_type_id` field so the
+                                payload is self-describing.
+                              - from_serializable() creates items when
+                                they are not present in the target
+                                cart (requires content_type_id); still
+                                updates pre-existing items when only
+                                quantity / unit_price change.
+                              - Legacy (pre-v3.0.11) payloads without
+                                content_type_id raise a clear
+                                ValueError instead of silently no-
+                                op'ing on a fresh cart.
+                              Backwards-compatible additive change —
+                              old payloads still work for updating
+                              existing items; they just fail loudly
+                              rather than silently when asked to
+                              restore into an empty cart.
+v3.0.12 .. v3.0.17 (patch)  → Remaining P0 bug fixes, one per release,
+                              each removing an @xfail marker as the
+                              fix:
                               3.0.12 = P0-2 (discount current_uses —
                                       gated, see note below)
                               3.0.13 = P0-3 (CARTS_SESSION_ADAPTER_CLASS)

--- a/tests/test_cart_serialization.py
+++ b/tests/test_cart_serialization.py
@@ -109,14 +109,73 @@ def test_from_serializable_with_empty_data_leaves_cart_untouched(cart, product, 
 
 
 # --------------------------------------------------------------------------- #
-# P0-1 regression (xfail removed in v3.0.11 — this commit's purpose)
+# P0-1: from_serializable restores items on a fresh cart (fixed in v3.0.11)
 # --------------------------------------------------------------------------- #
 
 def test_from_serializable_is_not_a_silent_noop_on_fresh_cart(rf_request, product):
-    """Calling from_serializable with items on a brand-new cart should
-    leave the cart populated. Today it silently returns an empty cart."""
-    data = {str(product.pk): {"quantity": 3, "unit_price": "15.00"}}
+    """Calling from_serializable with items on a brand-new cart must
+    populate it (P0-1 fix — pre-v3.0.11 this was a silent no-op)."""
+    from django.contrib.contenttypes.models import ContentType
+    from tests.test_app.models import FakeProduct
+
+    ct = ContentType.objects.get_for_model(FakeProduct)
+    data = {
+        str(product.pk): {
+            "content_type_id": ct.pk,
+            "quantity": 3,
+            "unit_price": "15.00",
+        }
+    }
 
     cart = Cart.from_serializable(rf_request, data)
 
-    assert not cart.is_empty()
+    assert cart.count() == 3
+    item = cart.cart.items.first()
+    assert item.quantity == 3
+    assert item.unit_price == Decimal("15.00")
+    assert item.object_id == product.pk
+
+
+def test_cart_serializable_includes_content_type_id(cart, product):
+    """The v3.0.11 output format includes content_type_id so payloads
+    can be fed to from_serializable on a fresh cart."""
+    from django.contrib.contenttypes.models import ContentType
+    from tests.test_app.models import FakeProduct
+
+    cart.add(product, Decimal("10.00"), quantity=1)
+
+    data = cart.cart_serializable()
+
+    ct = ContentType.objects.get_for_model(FakeProduct)
+    assert data[str(product.pk)]["content_type_id"] == ct.pk
+
+
+def test_cart_serializable_and_from_serializable_round_trip(cart, product):
+    """Serialising a populated cart and restoring into a fresh session
+    reproduces the original cart state."""
+    from django.test import RequestFactory
+
+    cart.add(product, Decimal("15.00"), quantity=3)
+    payload = cart.cart_serializable()
+
+    fresh_request = RequestFactory().get("/")
+    fresh_request.session = {}
+    restored = Cart.from_serializable(fresh_request, payload)
+
+    assert restored.count() == 3
+    item = restored.cart.items.first()
+    assert item.quantity == 3
+    assert item.unit_price == Decimal("15.00")
+    assert item.object_id == product.pk
+
+
+def test_from_serializable_raises_clear_error_on_legacy_payload(rf_request, product):
+    """Pre-v3.0.11 payloads (without content_type_id) cannot restore new
+    items; the method raises a clear ValueError instead of silently
+    no-op'ing, which was the P0-1 bug."""
+    legacy_payload = {
+        str(product.pk): {"quantity": 3, "unit_price": "15.00"},  # no content_type_id
+    }
+
+    with pytest.raises(ValueError, match="content_type_id"):
+        Cart.from_serializable(rf_request, legacy_payload)

--- a/tests/test_cart_serialization.py
+++ b/tests/test_cart_serialization.py
@@ -109,19 +109,9 @@ def test_from_serializable_with_empty_data_leaves_cart_untouched(cart, product, 
 
 
 # --------------------------------------------------------------------------- #
-# P0 regression — @xfail until the fix lands
+# P0-1 regression (xfail removed in v3.0.11 — this commit's purpose)
 # --------------------------------------------------------------------------- #
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "P0-1 — Cart.from_serializable is a silent no-op on a fresh cart. "
-        "The method only updates pre-existing items, so on an empty cart "
-        "nothing happens despite the docstring claiming 'restore a cart "
-        "from serializable data'. Scheduled for v3.0.11 (see "
-        "docs/ROADMAP_2026_04.md §P0-1)."
-    ),
-)
 def test_from_serializable_is_not_a_silent_noop_on_fresh_cart(rf_request, product):
     """Calling from_serializable with items on a brand-new cart should
     leave the cart populated. Today it silently returns an empty cart."""


### PR DESCRIPTION
## Summary

**First P0 fix after the P-1 test overhaul completed.** Resolves P0-1 (`docs/ROADMAP_2026_04.md` §P0-1): `Cart.from_serializable` silently no-op'd on a fresh cart despite its "restore a cart from serializable data" docstring. Runtime-verified during the original audit; covered by an `@pytest.mark.xfail(strict=True)` regression test in Phase 7.

## Two-commit structure

Per the P-1 workflow convention:

1. **`test(P0-1): remove xfail marker — next commit implements the fix`** — the 1-line `@xfail` removal. Test goes from expected-failure to plain-failure (red).
2. **`fix(P0-1): Cart.from_serializable actually restores items on a fresh cart`** — the fix + test-data updates + new tests + ROADMAP note. Test goes green.

Do **not** squash on merge — the commit split is the diff reviewers want.

## Design choice: Option 2 (create from payload), not Option 1 (rename)

The original roadmap fix menu offered two paths:

| Option | Approach | Chosen? |
|---|---|---|
| 1 | Rename method to `update_from_serializable`, document the update-only semantics | **No** |
| 2 | Actually create items from the payload | **Yes** |

Option 1 can't satisfy the Phase 7 xfail test (`assert not cart.is_empty()` after restore). The test locked us into Option 2; we honour that commitment here.

## Format change

`cart_serializable()` output gains a `content_type_id` field per item:

```json
{
  "42": {
    "content_type_id": 7,
    "total_price": "19.98",
    "unit_price": "9.99",
    "quantity": 2
  }
}
```

**Additive only.** Existing consumers that read `quantity` / `unit_price` / `total_price` are unaffected. The new field is what enables `from_serializable` to create items with the correct content-type relationship.

## Behaviour matrix

| Scenario | Before (≤v3.0.10) | After (v3.0.11) |
|---|---|---|
| `from_serializable` with new-format payload on fresh cart | Silent no-op (bug) | Items created ✓ |
| `from_serializable` with new-format payload on populated cart | Existing items updated | Existing items updated ✓ |
| `from_serializable` with legacy-format payload on populated cart | Existing items updated | Existing items updated ✓ |
| `from_serializable` with legacy-format payload on fresh cart | Silent no-op (bug) | **`ValueError`** with clear message |

The last row is the only breaking change: legacy payloads that would have silently failed now raise. Loud failure > silent failure; the error message explicitly names the version bump and tells the caller how to recover.

## New tests

- `test_from_serializable_is_not_a_silent_noop_on_fresh_cart` — Phase 7 xfail, now green. Data updated to include `content_type_id`.
- `test_cart_serializable_includes_content_type_id` — format lock-in so future regressions show up immediately.
- `test_cart_serializable_and_from_serializable_round_trip` — end-to-end: serialise → deserialise into a fresh session → identical cart state.
- `test_from_serializable_raises_clear_error_on_legacy_payload` — the new `ValueError` path for payloads missing `content_type_id`.

## Verification

```
uv run pytest → 283 passed, 3 xfailed in 13.50s
```

Was 279 passed + 4 xfailed → now 283 passed + 3 xfailed. The `-1` xfail became `+1` passing test; the three new tests add `+3`.

## What this closes / unlocks

- Closes **P0-1** (regression xfail removed).
- Unlocks the next P0 in the cascade: **P0-2** — `Discount.current_uses` never increments. Scheduled for v3.0.12.

## Test plan

- [ ] CI matrix green across all 18 Py×Django combinations.
- [ ] Reviewer checks the `ValueError` message on legacy payloads is actually actionable (names the version, tells callers what to do).
- [ ] Reviewer confirms the backwards-compat claim: any existing code that reads `payload[object_id]["quantity"]` etc still works. New `content_type_id` field is purely additive.
- [ ] Reviewer double-checks the `transaction.atomic()` wrap — if any item in the loop fails, no partial state is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)