### PR TITLE
ci: gate PyPI publish on tag pushes, not branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: ["master", "main"]
+    tags: ["v*"]
   pull_request:
     branches: ["master", "main"]
  
@@ -44,15 +45,13 @@ jobs:
     name: Publish to PyPI
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     concurrency:
       group: publish
       cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -65,18 +64,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install build twine
 
-      - name: Get latest tag
-        id: tag
-        run: |
-          TAG=$(git describe --tags --abbrev=0)
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          git checkout $TAG
-
       - name: Build package
         run: python -m build
 
       - name: Publish to PyPI
-        run: twine upload dist/*
+        run: twine upload --skip-existing dist/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Publish job was re-uploading the last tag on every master push, failing with PyPI 400 since the tag+version already existed.
- Gate publish on `startsWith(github.ref, 'refs/tags/v')` and trigger on tag pushes only. Drop the `git describe` / `git checkout` dance — actions/checkout now lands on the exact tagged commit.
- Add `twine upload --skip-existing` so re-pushing a tag is idempotent instead of 400.

## Why

Every PR merge to master has been failing CI since the publish scheme landed. The pattern is 100% consistent across recent history:

| Master push | Result | Why |
|---|---|---|
| PR merge (fix(P0-1)… #61) | FAIL | tried to republish v3.0.10 |
| "Bump version to 3.0.10" | SUCCESS | tag v3.0.10 was on HEAD |
| PR merge (Phase 8 #60) | FAIL | republished v3.0.9 |
| "Bump version to 3.0.9" | SUCCESS | tag v3.0.9 on HEAD |

`git describe --tags --abbrev=0` on a PR merge returns the previous tag (no new tag pushed yet). Build + upload → 400 because the file exists on PyPI already. "Bump version" commits succeeded only because they were pushed alongside a matching tag.

## Test plan

- [ ] This PR's CI run: `test` job runs on `pull_request`; `publish` job skipped (no tag ref). Merge to master should also skip publish.
- [ ] Next version bump: push tag `vX.Y.Z` → `test` job runs on the tagged commit, `publish` job uploads fresh artefact to PyPI.
- [ ] Re-pushing an existing tag should now no-op via `--skip-existing` instead of 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)