### PR TITLE
fix(P0-3): CARTS_SESSION_ADAPTER_CLASS is now honoured

### DIFF
--- a/cart/cart.py
+++ b/cart/cart.py
@@ -73,12 +73,13 @@ class Cart:
     """
 
     def __init__(self, request):
-        cart_id = request.session.get(CART_ID)
+        self._session = self._build_session_adapter(request)
+        cart_id = self._session.get_or_create_cart_id()
         cart = None
         if cart_id:
             cart = models.Cart.objects.filter(id=cart_id, checked_out=False).first()
         if cart is None:
-            cart = self._new(request)
+            cart = self._new()
         self.cart = cart
         self._cache: dict = {}
 
@@ -86,9 +87,29 @@ class Cart:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _new(self, request) -> models.Cart:
+    @staticmethod
+    def _build_session_adapter(request):
+        """Construct the session adapter named by ``CARTS_SESSION_ADAPTER_CLASS``.
+
+        Accepts either a dotted import path or a class object. If the
+        setting is unset, falls back to :class:`DjangoSessionAdapter`.
+        A bad dotted path raises ``ImportError`` — session storage is
+        too critical to silently fall back to the default (unlike the
+        tax / shipping / inventory factories).
+        """
+        from .session import DjangoSessionAdapter
+
+        adapter = getattr(settings, "CARTS_SESSION_ADAPTER_CLASS", None)
+        if adapter is None:
+            return DjangoSessionAdapter(request)
+        if isinstance(adapter, str):
+            from django.utils.module_loading import import_string
+            adapter = import_string(adapter)
+        return adapter(request)
+
+    def _new(self) -> models.Cart:
         cart = models.Cart.objects.create(creation_date=timezone.now())
-        request.session[CART_ID] = cart.id
+        self._session.set_cart_id(cart.id)
         return cart
 
     def _get_item(self, product) -> models.Item | None:

--- a/docs/ROADMAP_2026_04.md
+++ b/docs/ROADMAP_2026_04.md
@@ -1002,17 +1002,45 @@ v3.0.12 (this PR)           → P0-2 fix: Discount.current_uses now
                               behaviour in a patch" framing. The
                               obsolete validate=True gating plan in
                               the v3.1.0 entry below is now moot.
-v3.0.13 .. v3.0.17 (patch)  → Remaining P0 bug fixes, one per release,
+v3.0.13 (this PR)           → P0-3 fix: CARTS_SESSION_ADAPTER_CLASS
+                              is now actually read by Cart.__init__.
+                              Changes:
+                              - Cart.__init__ builds a session adapter
+                                from settings.CARTS_SESSION_ADAPTER_CLASS
+                                (dotted string or class object), default
+                                DjangoSessionAdapter. Cart never touches
+                                request.session directly anymore — all
+                                session I/O goes through the adapter's
+                                get_or_create_cart_id / set_cart_id.
+                              - Bad dotted path raises ImportError
+                                loudly. Session storage is too critical
+                                for the tax/shipping/inventory-style
+                                silent fallback.
+                              - Class-object form honoured too, matching
+                                the README example verbatim.
+                              Not fixed in this PR: the cart_link
+                              template tag still reads request.session
+                              directly (has deeper issues — force-
+                              creates a cart via Cart(request) so its
+                              "no cart" branch is dead). Follow-up.
+                              P0-4 (CookieSessionAdapter cookie round-
+                              trip) remains xfailed — the adapter is
+                              now pluggable, but the cookie adapter's
+                              HTTP round-trip is still broken. Both
+                              land together in 3.0.14.
+v3.0.14 .. v3.0.17 (patch)  → Remaining P0 bug fixes, one per release,
                               each removing an @xfail marker as the
                               fix:
-                              3.0.13 = P0-3 (CARTS_SESSION_ADAPTER_CLASS)
                               3.0.14 = P0-4 (CookieSessionAdapter
                                       round-trip)
-                              3.0.15 = P0-5 (README template-tag
-                                      examples — doc-only fix, no
-                                      xfail to remove)
+                              3.0.15 = SKIPPED — P0-5 (README template-
+                                      tag examples) rolls into the full
+                                      README rewrite at the tail of the
+                                      sequence, not released separately.
                               3.0.16 = P0-6 (CHANGELOG backfill)
                               3.0.17 = P0-7 (docs stale-banner)
+                              (final) = README full rewrite — supersedes
+                                       P0-5.
 v3.1.0 (minor)              → P1 block + P2-1, P2-2, P2-3, P2-9.
                               Cart.checkout() grows a validate kwarg.
                               Default is None → DeprecationWarning +

--- a/tests/test_cart_init.py
+++ b/tests/test_cart_init.py
@@ -96,19 +96,6 @@ def test_shared_session_yields_same_cart_across_requests():
     assert c1.cart.pk == c2.cart.pk
 
 
-# --------------------------------------------------------------------------- #
-# P0 regression — @xfail until the fix lands
-# --------------------------------------------------------------------------- #
-
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "P0-3 — CARTS_SESSION_ADAPTER_CLASS setting is documented in the "
-        "README but never read by Cart.__init__. The constructor hardcodes "
-        "request.session access. Scheduled for v3.0.13 (see "
-        "docs/ROADMAP_2026_04.md §P0-3)."
-    ),
-)
 def test_carts_session_adapter_class_setting_is_honoured(settings, rf_request):
     """Setting the adapter class should cause Cart to route session ops
     through it, leaving request.session untouched."""
@@ -118,7 +105,4 @@ def test_carts_session_adapter_class_setting_is_honoured(settings, rf_request):
 
     Cart(rf_request)
 
-    # Target behaviour: the adapter is used, so request.session stays clean.
-    # Current behaviour: Cart ignores the setting and writes CART-ID
-    # directly into request.session → assertion fails → xfail expected.
     assert CART_ID not in rf_request.session

--- a/tests/test_cart_init.py
+++ b/tests/test_cart_init.py
@@ -106,3 +106,42 @@ def test_carts_session_adapter_class_setting_is_honoured(settings, rf_request):
     Cart(rf_request)
 
     assert CART_ID not in rf_request.session
+
+
+def test_adapter_receives_the_new_cart_id_on_creation(settings, rf_request):
+    """The adapter's set_cart_id must be called with the freshly-created
+    cart's pk when the session had no prior cart."""
+    settings.CARTS_SESSION_ADAPTER_CLASS = (
+        "tests.test_cart_init._RecordingSessionAdapter"
+    )
+    _RecordingSessionAdapter.calls.clear()
+
+    cart = Cart(rf_request)
+
+    assert ("get_or_create_cart_id",) in _RecordingSessionAdapter.calls
+    assert ("set_cart_id", cart.cart.pk) in _RecordingSessionAdapter.calls
+
+
+def test_setting_accepts_a_class_object_not_just_a_dotted_string(
+    settings, rf_request
+):
+    """The README advertises both
+    ``CARTS_SESSION_ADAPTER_CLASS = MyAdapter`` and
+    ``= "dotted.path.MyAdapter"`` — both must work."""
+    settings.CARTS_SESSION_ADAPTER_CLASS = _RecordingSessionAdapter
+    _RecordingSessionAdapter.calls.clear()
+
+    Cart(rf_request)
+
+    assert CART_ID not in rf_request.session
+    assert ("get_or_create_cart_id",) in _RecordingSessionAdapter.calls
+
+
+def test_bad_dotted_path_raises_loudly_no_silent_fallback(settings, rf_request):
+    """Session storage is too critical to silently fall back to the
+    default on a typo — unlike the tax / shipping / inventory
+    factories. A bad dotted path must raise."""
+    settings.CARTS_SESSION_ADAPTER_CLASS = "nonexistent.module.FakeAdapter"
+
+    with pytest.raises(ImportError):
+        Cart(rf_request)


### PR DESCRIPTION
## Summary

- `Cart.__init__` now actually reads `settings.CARTS_SESSION_ADAPTER_CLASS` and routes all cart-id I/O through the resolved adapter. Accepts both a dotted string and a class object (matching the two forms advertised in the README).
- Default remains `DjangoSessionAdapter` when the setting is unset, so existing deployments are unaffected.
- Bad dotted paths raise `ImportError` loudly — no silent fallback. Session storage is too critical to follow the tax / shipping / inventory silent-fallback pattern.
- Three acceptance tests added (plus the unxfailed Phase 7 regression test).

## Two-commit TDD split

- **Commit A** (`9260bc8`) — removes the `@pytest.mark.xfail` only.
- **Commit B** (`4627210`) — the behaviour change turns it green.

**Do not squash.**

## Out of scope

The `cart_link` template tag still reads `request.session` directly (`cart/templatetags/cart_tags.py:79`). It has deeper issues — it force-creates a cart via `Cart(request)` before checking, making the "no cart" branch dead — and isn't covered by P0-3's xfail test. Flagged in the commit message + roadmap entry as a separate follow-up.

## Blocking relationship with P0-4

P0-3 makes the adapter pluggable; P0-4 fixes the `CookieSessionAdapter`'s failure to round-trip cookies. After this PR, `CookieSessionAdapter` can be selected via the setting but the HTTP round-trip still doesn't work (its own bug). The P0-4 xfail test remains; next release.

## Test plan

- [ ] CI — matrix green. `publish` job skipped (no tag ref).
- [ ] Local: `uv run pytest` → 291 passed, 1 xfailed (P0-4 only).
- [ ] Optional downstream sanity: set `CARTS_SESSION_ADAPTER_CLASS` to a custom adapter in a real project and confirm the adapter's `set_cart_id` fires on first request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)