### PR TITLE
fix(P0-4): CookieSessionAdapter now round-trips HTTP cookies

### DIFF
--- a/cart/session.py
+++ b/cart/session.py
@@ -77,7 +77,7 @@ class CookieSessionAdapter(CartSessionAdapter):
     def __init__(self, request=None, response=None):
         self._request = request
         self._response = response
-        self._cookies = {}
+        self._cookies = dict(request.COOKIES) if request is not None else {}
 
     def get(self, key: str, default: Any = None) -> Any:
         return self._cookies.get(key, default)

--- a/docs/ROADMAP_2026_04.md
+++ b/docs/ROADMAP_2026_04.md
@@ -1028,19 +1028,41 @@ v3.0.13 (this PR)           → P0-3 fix: CARTS_SESSION_ADAPTER_CLASS
                               now pluggable, but the cookie adapter's
                               HTTP round-trip is still broken. Both
                               land together in 3.0.14.
-v3.0.14 .. v3.0.17 (patch)  → Remaining P0 bug fixes, one per release,
-                              each removing an @xfail marker as the
-                              fix:
-                              3.0.14 = P0-4 (CookieSessionAdapter
-                                      round-trip)
-                              3.0.15 = SKIPPED — P0-5 (README template-
-                                      tag examples) rolls into the full
-                                      README rewrite at the tail of the
-                                      sequence, not released separately.
+v3.0.14 (this PR)           → P0-4 fix: CookieSessionAdapter now
+                              round-trips cookies via real HTTP
+                              headers.
+                              Changes:
+                              - CookieSessionAdapter.__init__ seeds
+                                self._cookies from request.COOKIES when
+                                a request is passed. Previously
+                                self._cookies started empty on every
+                                request, so cart ids written to one
+                                response were lost on the next.
+                              - Phase 7 xfail test had its own bug —
+                                RequestFactory().get("/", COOKIES={...})
+                                silently drops the kwarg (only HTTP_*
+                                headers are honoured). The xfail
+                                mask was hiding it. Fixed to use
+                                HTTP_COOKIE="CART-ID=…" which is what
+                                Django actually parses.
+                              - Added a narrower init-hydration test so
+                                future regressions surface with a
+                                clearer failure mode before reaching
+                                the end-to-end round-trip test.
+                              Every P0-bug xfail is now resolved. The
+                              suite runs with zero xfails. Next
+                              releases are documentation-only
+                              (CHANGELOG backfill, stale-doc banners,
+                              README full rewrite).
+v3.0.15 = SKIPPED             — P0-5 (README template-tag examples)
+                              rolls into the full README rewrite at
+                              the tail of the sequence, not released
+                              separately.
+v3.0.16 .. v3.0.17 (patch)  → Doc-only releases:
                               3.0.16 = P0-6 (CHANGELOG backfill)
                               3.0.17 = P0-7 (docs stale-banner)
-                              (final) = README full rewrite — supersedes
-                                       P0-5.
+                              (final) = README full rewrite —
+                                       supersedes P0-5.
 v3.1.0 (minor)              → P1 block + P2-1, P2-2, P2-3, P2-9.
                               Cart.checkout() grows a validate kwarg.
                               Default is None → DeprecationWarning +

--- a/tests/test_session_adapters.py
+++ b/tests/test_session_adapters.py
@@ -182,20 +182,6 @@ def test_cookie_adapter_delete_on_missing_key_is_noop():
     assert "never-set" not in adapter._cookies
 
 
-# --------------------------------------------------------------------------- #
-# P0 regression — @xfail until the fix lands
-# --------------------------------------------------------------------------- #
-
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "P0-4 — CookieSessionAdapter.__init__ never populates self._cookies "
-        "from request.COOKIES, so a cart id set on one request is not "
-        "recoverable on the next. The in-memory round-trip works (previous "
-        "tests); the HTTP round-trip does not. Scheduled for v3.0.14 "
-        "(see docs/ROADMAP_2026_04.md §P0-4)."
-    ),
-)
 def test_cookie_session_adapter_round_trips_via_real_request_cookies():
     """Two sequential requests sharing a cookie jar should see the same
     cart id — the canonical cookie-session-adapter contract."""

--- a/tests/test_session_adapters.py
+++ b/tests/test_session_adapters.py
@@ -182,6 +182,25 @@ def test_cookie_adapter_delete_on_missing_key_is_noop():
     assert "never-set" not in adapter._cookies
 
 
+def test_cookie_init_hydrates_cookies_dict_from_request_COOKIES():
+    """Focused regression test for P0-4. If __init__ ever stops copying
+    request.COOKIES into self._cookies, the HTTP round-trip breaks —
+    this test catches that before it reaches the end-to-end round-trip
+    test below and gives a clearer failure mode.
+
+    Uses ``HTTP_COOKIE`` because ``RequestFactory`` does not accept a
+    ``COOKIES=`` kwarg — it silently drops it. The header form is what
+    Django actually parses in production.
+    """
+    from django.test import RequestFactory
+
+    request = RequestFactory().get("/", HTTP_COOKIE="CART-ID=7; other=keep")
+    adapter = CookieSessionAdapter(request=request)
+
+    assert adapter._cookies["CART-ID"] == "7"
+    assert adapter._cookies["other"] == "keep"
+
+
 def test_cookie_session_adapter_round_trips_via_real_request_cookies():
     """Two sequential requests sharing a cookie jar should see the same
     cart id — the canonical cookie-session-adapter contract."""
@@ -195,9 +214,10 @@ def test_cookie_session_adapter_round_trips_via_real_request_cookies():
 
     cart_id_cookie = response.cookies["CART-ID"].value
 
-    # Request 2: browser echoes the cookie back; Django populates
-    # request.COOKIES from it. The adapter must hydrate from that.
-    request = RequestFactory().get("/", COOKIES={"CART-ID": cart_id_cookie})
+    # Request 2: browser echoes the cookie back via the Cookie header;
+    # Django populates request.COOKIES from it. The adapter must
+    # hydrate from that.
+    request = RequestFactory().get("/", HTTP_COOKIE=f"CART-ID={cart_id_cookie}")
     reader = CookieSessionAdapter(request=request)
 
     assert reader.get_or_create_cart_id() == 42


### PR DESCRIPTION
## Summary

- `CookieSessionAdapter.__init__` now seeds `self._cookies` from `request.COOKIES` when a request is passed. Previously the dict started empty on every request, so a cart id written to one response was never recoverable on the next.
- The Phase 7 xfail regression test itself had a bug: `RequestFactory().get("/", COOKIES={...})` silently drops the kwarg — only `HTTP_*` extras are honoured. The `xfail` marker was masking it. Fixed to use `HTTP_COOKIE="CART-ID=42"`, which is what Django actually parses.
- Added a narrower init-hydration test so future regressions fail with a clearer message before reaching the end-to-end round-trip test.

## Two-commit TDD split

- **Commit A** (`f8af96f`) — removes the `@pytest.mark.xfail` only.
- **Commit B** (`112c961`) — fixes the production code AND the test's own bug in one commit. The test was wrong in a way xfail hid; splitting the two fixes would leave a state where the production fix is landed but the test still fails due to its own bug.

**Do not squash.**

## Last P0 xfail resolved

After this PR the suite runs with **zero xfails** (`293 passed, 0 xfailed`). Every P0 regression test authored in Phase 7 is now green. Remaining P0 work is doc-only:

- P0-6 — CHANGELOG backfill (v3.0.16)
- P0-7 — stale-doc banners (v3.0.17)
- README full rewrite (supersedes P0-5) — final

## Test plan

- [ ] CI green across the matrix. Publish skipped (no tag ref).
- [ ] `uv run pytest` locally → 293 passed, 0 xfailed.
- [ ] Optional downstream: configure `CARTS_SESSION_ADAPTER_CLASS = "cart.session.CookieSessionAdapter"`, hit two endpoints in sequence from a browser, confirm the cart survives across requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)