### PR TITLE
docs(P0-7): superseded banners on stale docs; ROADMAP.md → pointer

### DIFF
--- a/docs/PROJECT_ANALYSIS.md
+++ b/docs/PROJECT_ANALYSIS.md
@@ -1,5 +1,26 @@
 # django-cart Project Analysis
 
+> [!warning] Status: superseded (kept for historical reference)
+> This audit was written in March 2026 against **version 2.2.13**,
+> before v3.0.0 shipped discounts, tax, shipping, and inventory
+> checking. Several findings are now out of date:
+>
+> - "100% code coverage" — the current figure is **94%**, and
+>   coverage is treated as informational, not a merge gate.
+> - Recommendations for discounts / tax / shipping / inventory —
+>   **shipped in v3.0.0** (`cart/inventory.py`, `cart/shipping.py`,
+>   `cart/tax.py`, `cart/models.Discount`). See
+>   [`CHANGELOG.md`](../CHANGELOG.md#300--2026-03-29).
+> - Repo audits newer than this one: first
+>   [`PROJECT_ANALYSIS_2026_03_29_0243am.md`](PROJECT_ANALYSIS_2026_03_29_0243am.md)
+>   (version 3.0.1) — also superseded — and then the current plan of
+>   record, [`ROADMAP_2026_04.md`](ROADMAP_2026_04.md).
+>
+> For the active roadmap, issue list, and acceptance criteria, go to
+> **[`ROADMAP_2026_04.md`](ROADMAP_2026_04.md)**. This file is kept
+> on disk so prior links continue to resolve; treat its contents as
+> historical snapshot, not current guidance.
+
 **Analyst:** Senior E-Commerce Software Engineer  
 **Date:** March 2026  
 **Version Analyzed:** 2.2.13  

--- a/docs/PROJECT_ANALYSIS_2026_03_29_0243am.md
+++ b/docs/PROJECT_ANALYSIS_2026_03_29_0243am.md
@@ -1,5 +1,27 @@
 # Project Analysis: django-cart
 
+> [!warning] Status: superseded (kept for historical reference)
+> This audit was written 2026-03-29 against **version 3.0.1**. It
+> predates the P-1 test overhaul (v3.0.3–v3.0.10) and the P0 bug
+> fixes (v3.0.11–v3.0.14 unreleased as of 2026-04-21). Several of
+> the risks and observations listed below have since been resolved
+> or explicitly re-scoped:
+>
+> - Test framework migrated from `unittest.TestCase` to pytest +
+>   pytest-django (P-1 overhaul, complete).
+> - P0 bugs identified here — `Cart.from_serializable`,
+>   `Discount.current_uses`, `CARTS_SESSION_ADAPTER_CLASS`,
+>   `CookieSessionAdapter` cookie round-trip — now fixed with
+>   TDD regression tests. See [`CHANGELOG.md`](../CHANGELOG.md)
+>   `[Unreleased]` section.
+> - Coverage and quality-gate plans have been revised.
+>
+> For the active plan of record (current phase, per-item
+> motivation, acceptance criteria, release sequence), go to
+> **[`ROADMAP_2026_04.md`](ROADMAP_2026_04.md)**. This file is kept
+> on disk so prior links resolve; treat its contents as a dated
+> snapshot, not current guidance.
+
 **Date:** March 29, 2026, 02:43 AM  
 **Analyst:** Senior Software Engineer (Python/Django/E-commerce Specialist)  
 **Version Analyzed:** 3.0.1  

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,42 +1,22 @@
-# django-cart Development Roadmap
+# django-cart Roadmap
 
-**Current Version:** 3.0.0  
-**Last Updated:** March 2026  
-**Repository:** https://github.com/bmentges/django-cart
+> [!warning] This file has been superseded.
+> The active plan of record is
+> **[`docs/ROADMAP_2026_04.md`](ROADMAP_2026_04.md)**.
+> Please open that file for:
+>
+> - the current phase and release sequence (P-1 through P3),
+> - per-item motivation, fix plans, and acceptance criteria,
+> - historical decisions (what was shipped, skipped, or deferred).
+>
+> The short "Future Considerations" list that used to live here has
+> been folded into `ROADMAP_2026_04.md` §P3 — see that section for
+> features under consideration (multi-currency, cart sharing, cart
+> expiration, saved carts, async API, etc.) along with their status.
+>
+> Any future *dated* roadmap snapshots (e.g. `ROADMAP_2027_01.md`)
+> should be added alongside `ROADMAP_2026_04.md` rather than by
+> mutating this file.
 
----
-
-## Future Considerations
-
-The following features are marked for future consideration and are not yet scheduled:
-
-| Feature | Priority | Notes |
-|---------|----------|-------|
-| Multi-currency support | Low | Complex currency conversion |
-| Gift wrapping options | Low | Requires order customization |
-| Cart notes field | Medium | Simple addition |
-| Saved carts | Medium | User preference feature |
-| Cart sharing | Low | Social commerce feature |
-| Abandoned cart emails | Medium | Requires user identification |
-| Cart expiration | Medium | Background task integration |
-| Async cart operations | Low | Django async view support |
-
-### Potential Deprecations
-
-| Feature | Reason | Timeline |
-|---------|--------|----------|
-| `Cart._new()` private method | Internal API may change | v4.0.0 |
-| Session key format | May need to change for scalability | v4.0.0 |
-
----
-
-## Version Compatibility
-
-| Version | Python | Django |
-|---------|--------|--------|
-| v3.0.0 | 3.10+ | 4.2+ |
-
----
-
-*Roadmap maintained by project maintainers*  
-*Last updated: March 2026*
+This stub is kept so existing links and bookmarks continue to
+resolve.


### PR DESCRIPTION
## Summary

- `docs/ROADMAP.md` content replaced with a short pointer to `docs/ROADMAP_2026_04.md` (current plan of record). Stub kept on disk so prior links / bookmarks continue to resolve.
- `docs/PROJECT_ANALYSIS.md` (March 2026, analysed v2.2.13) — `[!warning]` callout prepended naming the specific stale claims: "100% coverage", pre-v3.0.0 recommendations (discounts / tax / shipping / inventory) that have since shipped, link to newer audit and active roadmap.
- `docs/PROJECT_ANALYSIS_2026_03_29_0243am.md` (analysed v3.0.1) — `[!warning]` callout prepended noting what's now resolved (P-1 overhaul complete; P0-1 through P0-4 fixed), with a pointer to the active roadmap.

## Why

Readers landing on these files via GitHub search or repo browsing were getting outdated context — e.g. the "100% coverage" claim directly contradicts the 94% real figure, and the pre-v3.0.0 feature recommendations were being mistaken for unimplemented work. No structural rewrite or deletion — just banners so the existing content is correctly framed as historical snapshot.

## Doc-only

No code, no tests, no behaviour change. Suite unaffected (still 293 passed / 0 xfailed).

## Remaining P0 sequence

- Full README rewrite (supersedes P0-5). **Final task.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)