### PR TITLE
docs: relicense to MIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Merged to `master` but not yet tagged on PyPI.
 
+### Changed — Licensing
+
+- **Relicensed from LGPL-3.0 to MIT.** Downstream projects can now
+  embed, modify, and redistribute `django-cart` under any license
+  compatible with MIT (including proprietary). The only requirement
+  is to preserve the copyright notice and the permission notice in
+  substantial copies. Prior tagged releases (v2.x and v3.0.0
+  through v3.0.10) remain available under LGPL-3.0; only v3.0.11
+  onward is MIT-licensed.
+
 ### Added
 - `cart_serializable()` output now includes `content_type_id` per item so
   the payload is self-describing and can restore into a fresh cart.
@@ -17,6 +27,15 @@ Merged to `master` but not yet tagged on PyPI.
 - CHANGELOG backfilled for v3.0.0–v3.0.10; adopted Keep-a-Changelog
   headings. Added CI step that fails if `CHANGELOG.md` does not mention
   the current `pyproject.toml` version.
+- Full README rewrite (educational tone, engineers + agents audience,
+  five Mermaid diagrams, corrected template-tag signatures, correct
+  custom session-adapter interface).
+- `docs/AGENTS.md` — guide for coding-agent-driven extension of
+  downstream projects that use `django-cart`.
+- Roadmap `docs/ROADMAP_2026_04.md` §P3-10 reserves a slot for
+  high-precision decimal representation (cryptocurrency-style
+  fractional quantities) as a near-future feature. No code change
+  yet.
 
 ### Changed
 - `Cart.checkout()` is now idempotent — calling it twice on the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,10 @@ templatetags, signals, pluggable calculators) exists to support that class.
 - Python: **3.10+**, Django: **4.2+** (CI matrix up to Py 3.14 / Dj 6.0)
 - Current version: see `pyproject.toml` (`version` field). Bump this when
   releasing; CI publishes on tag push.
-- License: **LGPL-3.0** (`LICENSE`). Keep this in mind if copying code in from
-  other projects.
+- License: **MIT** (`LICENSE`). Relicensed from LGPL-3.0 in v3.0.11 —
+  see `CHANGELOG.md` for the rationale. Copying code in from other MIT /
+  BSD / Apache-2.0 projects is fine; avoid copying from GPL / LGPL /
+  AGPL sources without clearing it first.
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,165 +1,21 @@
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+MIT License
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+Copyright (c) 2011-2026 Bruno Mentges de Carvalho
 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-  0. Additional Definitions.
-
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
-
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
-
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
-
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
-
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
-
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
-
-  1. Exception to Section 3 of the GNU GPL.
-
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
-
-  2. Conveying Modified Versions.
-
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
-
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
-
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
-
-  3. Object Code Incorporating Material from Library Header Files.
-
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
-
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
-
-  4. Combined Works.
-
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
-
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
-
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
-
-   d) Do one of the following:
-
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
-
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
-
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
-
-  5. Combined Libraries.
-
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
-
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![PyPI](https://img.shields.io/pypi/v/django-cart?style=for-the-badge&logo=pypi&logoColor=white&label=PyPI)
 ![Python](https://img.shields.io/badge/Python-3.10%2B-informational?style=for-the-badge&logo=python&logoColor=white)
 ![Django](https://img.shields.io/badge/Django-4.2%2B-0C4B33?style=for-the-badge&logo=django&logoColor=white)
-![License](https://img.shields.io/badge/License-LGPL--3.0-8A2BE2?style=for-the-badge)
+![License](https://img.shields.io/badge/License-MIT-green?style=for-the-badge)
 
 # django-cart
 
@@ -1032,7 +1032,8 @@ Django 6.0.
 - **Changelog:** [`CHANGELOG.md`](CHANGELOG.md) — Keep-a-Changelog
   format.
 - **Roadmap of record:** [`docs/ROADMAP_2026_04.md`](docs/ROADMAP_2026_04.md).
-- **License:** LGPL-3.0. See [`LICENSE`](LICENSE).
+- **License:** MIT. See [`LICENSE`](LICENSE). (Relicensed from
+  LGPL-3.0 in v3.0.11 — see `CHANGELOG.md`.)
 
 Contributions welcome. The library is small on purpose — if a
 feature fits the "session-backed cart" mission, open an issue or

--- a/docs/ROADMAP_2026_04.md
+++ b/docs/ROADMAP_2026_04.md
@@ -1135,8 +1135,9 @@ calendar deadlines beyond "4.0 no sooner than October 2026".
   deliberately framework-agnostic at the view layer.
 - Migrating away from `ContentType` generic FKs. It's the headline feature.
 - Supporting Django <4.2 or Python <3.10. Already dropped.
-- Replacing LGPL-3.0 with a more permissive license. Maintainer-only
-  decision.
+- ~~Replacing LGPL-3.0 with a more permissive license. Maintainer-only
+  decision.~~ **Done** in v3.0.11 — relicensed to MIT. See
+  `CHANGELOG.md` [Unreleased] / [3.0.11].
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "A simple session-backed shopping cart for modern Django."
 readme = "README.md"
-license = { text = "LGPL-3.0" }
+license = { text = "MIT" }
 requires-python = ">=3.10"
 dependencies = [
     "Django>=4.2",


### PR DESCRIPTION
## Summary

Replaces the LGPL-3.0 license with the MIT License across the repo.

## What changes

| File | Change |
|---|---|
| `LICENSE` | FSF LGPL-3.0 text replaced with the SPDX MIT template. Copyright: `2011–2026 Bruno Mentges de Carvalho` (project inception → current year). |
| `pyproject.toml` | `license = { text = "LGPL-3.0" }` → `{ text = "MIT" }`. Will flow into wheel metadata / PyPI classifier on next build. |
| `README.md` | License badge switched from LGPL-3.0 (violet) to MIT (green). License footer cites the relicense and refers to the CHANGELOG. |
| `CLAUDE.md` | Project-rules note updated. Still cautions against copying from GPL / LGPL / AGPL sources going forward. |
| `docs/ROADMAP_2026_04.md` | "Out of scope" line "Replacing LGPL-3.0 … Maintainer-only decision" marked strikethrough + done. |
| `docs/PROJECT_ANALYSIS_2026_03_29_0243am.md` | **Not edited** — it's a dated historical snapshot (superseded banner already prepended in P0-7); rewriting its "License: LGPL-3.0" line would falsify the record. |
| `CHANGELOG.md` | New `[Unreleased]` **Changed — Licensing** section at the top. Also backfills the doc entries from PR #68 (README rewrite, `docs/AGENTS.md`, P3-10 roadmap slot). |

## Contributor consent

Git log shows 18 distinct contributors beyond the primary maintainer. Per the maintainer's direction: those contributions were to the pre-3.0.0 codebase, which has since been substantially rewritten. The current v3.0.x surface (discounts, tax, shipping, inventory, pluggable session adapter, pytest harness, atomic / concurrency-safe checkout) is entirely maintainer-authored. Proceeding on that judgment. Prior tagged releases (v2.x, v3.0.0 through v3.0.10) remain available under LGPL-3.0 on PyPI and Git — only v3.0.11 onward is MIT.

## Test plan

- [ ] CI `test` job green across the matrix.
- [ ] CI `changelog` job green — `## [3.0.10]` still exists.
- [ ] `publish` skipped (no tag ref).
- [ ] Visually: PyPI classifier renders "MIT" after the next tagged release.

## After this merges

Recommended next step on your side: bump `pyproject.toml` to `3.0.11`, promote the CHANGELOG `[Unreleased]` header to `## [3.0.11] — YYYY-MM-DD`, tag and push. The relicense, the four P0 code fixes, the CHANGELOG adoption, the stale-doc banners, the README rewrite, `docs/AGENTS.md`, and the P3-10 roadmap slot will all flow into one PyPI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)