### PR TITLE
ci+docs: drop Py3.14×Django<6 combos; document the upstream incompat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,19 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         django-version: ["4.2", "5.0", "5.1", "6.0"]
         exclude:
+          # Django 6.0 requires Python 3.12+.
           - python-version: "3.10"
             django-version: "6.0"
           - python-version: "3.11"
             django-version: "6.0"
+          # Python 3.14 requires Django 6.0+ — earlier Django has a
+          # Context.__copy__ incompatibility. See README §Compatibility.
+          - python-version: "3.14"
+            django-version: "4.2"
+          - python-version: "3.14"
+            django-version: "5.0"
+          - python-version: "3.14"
+            django-version: "5.1"
  
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -1018,8 +1018,40 @@ reflection) tests.
 
 **Python 3.10+, Django 4.2+.**
 
-The CI matrix exercises the full range up to Python 3.14 and
-Django 6.0.
+### Compatibility matrix
+
+|              | Django 4.2 | Django 5.0 | Django 5.1 | Django 6.0 |
+|--------------|:----------:|:----------:|:----------:|:----------:|
+| Python 3.10  |     ✅     |     ✅     |     ✅     |      —     |
+| Python 3.11  |     ✅     |     ✅     |     ✅     |      —     |
+| Python 3.12  |     ✅     |     ✅     |     ✅     |     ✅     |
+| Python 3.13  |     ✅     |     ✅     |     ✅     |     ✅     |
+| Python 3.14  |     ❌     |     ❌     |     ❌     |     ✅     |
+
+- ✅ exercised in CI.
+- ❌ unsupported — see the callout below.
+- — this Python version is outside the upstream Django release's
+  supported Python range.
+
+> [!warning] **Python 3.14 requires Django 6.0+**
+> `django-cart` does **not** support Python 3.14 paired with Django
+> 4.2, 5.0, or 5.1 — and will not. The incompatibility is upstream in
+> Django itself.
+>
+> **Why it breaks.** Django's `django.template.Context.__copy__`
+> (pre-6.0) assigns `duplicate.dicts = self.dicts[:]` onto a value
+> returned by `copy(super())`, i.e. a `super()` proxy. Python 3.14
+> no longer permits attribute assignment on `super()` proxies, so any
+> template render under Py3.14 + Django<6 raises
+> `AttributeError: 'super' object has no attribute 'dicts' and no
+> __dict__ for setting new attributes`.
+>
+> Django fixed `Context.__copy__` in 6.0. There is nothing
+> `django-cart` can patch on its side — the break is in Django's
+> template engine, not in this library.
+>
+> **What to do.** On Python 3.14, upgrade to Django 6.0+. On earlier
+> Django, stay on Python 3.13 or below.
 
 ---
 

--- a/tests/test_cart_admin.py
+++ b/tests/test_cart_admin.py
@@ -9,36 +9,14 @@ the actual user-facing admin surface via the Django test client.
 """
 from __future__ import annotations
 
-import sys
 from decimal import Decimal
 
-import django
 import pytest
 
 from cart.models import Cart as CartModel
 
 
-# Django <6.0 Context.__copy__ assigns to a super() proxy, which Python
-# 3.14 forbids. The test client's template-capture instrumentation fires
-# it on every admin page render, so we can't cover admin via the Client
-# on that combo. Not a django-cart bug; Django fixed Context.__copy__
-# in 6.0. Coverage still runs on every other combo (py3.10–3.13 × all
-# Django, and py3.14 × Django 6.0+).
-_DJANGO_CONTEXT_COPY_BROKEN_ON_PY314 = (
-    sys.version_info >= (3, 14) and django.VERSION[:2] < (6, 0)
-)
-
-pytestmark = [
-    pytest.mark.django_db,
-    pytest.mark.skipif(
-        _DJANGO_CONTEXT_COPY_BROKEN_ON_PY314,
-        reason=(
-            "Django <6.0 Context.__copy__ incompatible with Python 3.14 "
-            "test-client instrumentation (assigns to super() proxy). "
-            "Fixed in Django 6.0; unrelated to django-cart."
-        ),
-    ),
-]
+pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture

--- a/tests/test_cookie_session_middleware.py
+++ b/tests/test_cookie_session_middleware.py
@@ -122,11 +122,10 @@ def test_middleware_is_noop_when_request_never_constructed_a_cart():
     response — the middleware's guard on ``request._cart_session``
     prevents a crash on the majority of non-cart routes.
 
-    Unit-level rather than HTTP-level: a client-driven version would
-    hit a template-rendering admin route, which trips a pre-existing
-    Py3.14 + Django<6 ``Context.__copy__`` bug (see
-    ``tests/test_cart_admin.py`` for the skip pattern). The guard is
-    fully covered by exercising the middleware directly.
+    Unit-level rather than HTTP-level: driving this through Client +
+    an admin route would couple the test to whichever default handler
+    renders the template, which adds no coverage on top of asserting
+    the guard directly.
     """
     from django.http import HttpResponse
     from django.test import RequestFactory

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from django.http import HttpResponse
 from django.urls import path
 
 from tests.test_app import views
@@ -12,19 +11,3 @@ urlpatterns = [
     path("cart/update/<int:product_id>/", views.cart_update, name="cart_update"),
     path("cart/checkout/", views.cart_checkout, name="cart_checkout"),
 ]
-
-
-def _bare_404(request, exception=None):
-    # Django's default page_not_found view renders a template, which
-    # fires the template_rendered signal. The test client's
-    # store_rendered_templates handler copies the template Context via
-    # Context.__copy__ — which on Python 3.14 + Django <6.0 raises
-    # AttributeError because Django assigns to a super() proxy that
-    # Py3.14 no longer permits. Returning a bare response here skips
-    # template rendering entirely, dodging the bug. Not a django-cart
-    # issue; fixed in Django 6.0. Safe for our test suite because no
-    # existing test asserts on default 404 HTML output.
-    return HttpResponse(status=404)
-
-
-handler404 = _bare_404


### PR DESCRIPTION
## Summary

- **Excludes Python 3.14 × Django 4.2/5.0/5.1 from the CI matrix.** The incompatibility is upstream: Django's `template.Context.__copy__` assigns to a `super()` proxy, which Python 3.14 no longer permits. Django fixed it in 6.0; there is nothing this library can patch.
- **Deletes the two in-repo workarounds** that existed solely to dodge this bug on the broken combo:
  - The module-level `skipif` in `tests/test_cart_admin.py`.
  - The bespoke `_bare_404` handler in `tests/urls.py`.
- **Documents the unsupported combo prominently** in the README's Requirements section — compatibility matrix + warning callout with the technical reason and the guidance ("on Py3.14, upgrade to Django 6.0+").

## Test plan

- [x] `uv run pytest` on Py3.12 × Django 6.0 — 301 passed
- [x] Compatibility matrix in README reflects the new exclude list
- [x] `skipif`/`_bare_404` workaround deletions verified by running the full suite (nothing else referenced them)
- [ ] CI matrix produces exactly the cells marked ✅ in the README matrix (verified once CI runs)

## Notes for reviewer

- No version bump — this is CI + docs, no behavioural change for downstream consumers.
- The supported column stays: `3.10–3.13 × 4.2/5.0/5.1`, plus `3.12–3.14 × 6.0`. Nothing we previously promised goes away.
- If you'd prefer a softer stance ("may be made to work in a future release") instead of "will not," I can tone the callout down — the break is genuinely upstream, but language is easy to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)