### PR TITLE
fix(P1-C): template tags no longer create Cart rows; cart_link drops id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`pytest --ds=tests.settings_custom_user tests/test_cart_custom_user.py`)
   to prove the library installs and operates on projects with a
   custom user model.
+- `CART_DETAIL_URL_NAME` setting — URL name used by `{% cart_link %}`
+  to resolve the anchor via `reverse()`. Optional; defaults to
+  `/cart/` when unset.
 
 ### Fixed
 - **P1-A** · `Cart.checkout()` is now idempotent across facades. Before
@@ -38,11 +41,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unapplicable under a swapped user model). Projects on the default
   `auth.User` are unaffected; the swappable reference resolves to the
   same target.
+- **P1-C** · Template tags no longer create Cart rows as a side
+  effect of rendering. `cart_item_count`, `cart_summary`, and
+  `cart_is_empty` read directly from the DB using the session's
+  existing `CART-ID` and return defaults when no cart id is bound;
+  `cart_link` never touches the cart at all. Before this release, any
+  site using these tags in a header created one abandoned row per
+  bot, crawler, healthcheck, and anonymous pageview.
+- **P1-C** · `cart_link` no longer embeds the cart's integer primary
+  key in the URL (the old `/cart/{id}/` shape leaked sequential DB
+  ids to referrers, analytics, and third-party scripts). The tag
+  resolves the target via `reverse(CART_DETAIL_URL_NAME)` when the
+  new setting is configured, falling back to a static `/cart/`
+  otherwise or on `NoReverseMatch`.
 
 ### Docs
 - README `Checkout` section, the concurrency warning in
   `Using the Cart`, and the discount-enforcement sequence diagram now
   reflect the P1-A fix (Cart row is locked, not just the Discount row).
+- README Template Tags section adds a callout that the tags are
+  row-side-effect-free plus a `CART_DETAIL_URL_NAME` example, and the
+  Settings Reference table lists the new setting.
 - Removed two dead links to the unwritten `docs/ROADMAP_2026_04.md`;
   both references now point at `docs/ANALYSIS.md`.
 

--- a/README.md
+++ b/README.md
@@ -793,6 +793,27 @@ OPTIONS → context_processors`).
 All four tags declare `takes_context=True` and read `request` from
 the template context. Do not pass `request` positionally.
 
+> [!note] Tags do not create abandoned cart rows
+> The three read-only tags (`cart_item_count`, `cart_summary`,
+> `cart_is_empty`) query the cart directly from the DB when the
+> session already carries a `CART-ID`, and return defaults otherwise.
+> `cart_link` never queries the cart at all. Loading any of these in
+> a site-wide header is safe to serve to crawlers, bots, and
+> pre-login visitors — none of them will materialise a DB row.
+
+> [!tip] Route `cart_link` through your own URL conf
+> Set `CART_DETAIL_URL_NAME` to a URL name you've defined, and
+> `cart_link` will resolve the anchor via `reverse()`:
+>
+> ```python
+> # settings.py
+> CART_DETAIL_URL_NAME = "cart_detail"
+> ```
+>
+> With the setting absent — or the URL name unresolvable — the tag
+> falls back to a static `/cart/`. The cart's integer primary key is
+> never embedded in the URL.
+
 Example header snippet:
 
 ```django
@@ -832,6 +853,7 @@ or `None`.
 | `CARTS_SESSION_ADAPTER_CLASS` | dotted path or class | `DjangoSessionAdapter` | Where the integer cart id is stored. See [Session Storage](#session-storage). |
 | `CART_MAX_QUANTITY_PER_ITEM` | int or `None` | `None` (unlimited) | Cap on `item.quantity`. Exceeding raises `InvalidQuantity`. |
 | `CART_MIN_ORDER_AMOUNT` | `Decimal` or `None` | `None` (no minimum) | Minimum `cart.summary()` required for `can_checkout()` to return `True`. |
+| `CART_DETAIL_URL_NAME` | str or `None` | `None` | URL name passed to `reverse()` by the `{% cart_link %}` template tag. Falls back to a static `/cart/` when unset or unresolvable. See [Template Tags](#template-tags). |
 
 ---
 

--- a/cart/templatetags/cart_tags.py
+++ b/cart/templatetags/cart_tags.py
@@ -1,11 +1,31 @@
 from decimal import Decimal
 
 from django import template
+from django.conf import settings
+from django.db.models import F, Sum
+from django.urls import NoReverseMatch, reverse
 from django.utils.html import format_html
 
-from ..cart import Cart
+from ..cart import CART_ID
+from ..models import Cart as CartModel, Item
 
 register = template.Library()
+
+
+def _session_cart_id(request) -> int | None:
+    """Read CART-ID from the request session without touching the ORM.
+
+    Read-only template tags share this helper so a render on a fresh
+    visitor (no CART-ID yet) is a zero-query zero-mutation path —
+    crucially, it does not call ``Cart(request)`` and therefore does
+    not materialise a :class:`cart.models.Cart` row (P1-C, v3.0.13).
+    """
+    if request is None:
+        return None
+    session = getattr(request, "session", None)
+    if session is None:
+        return None
+    return session.get(CART_ID)
 
 
 @register.simple_tag(takes_context=True)
@@ -16,13 +36,16 @@ def cart_item_count(context) -> int:
     Usage::
 
         {% load cart_tags %}
-        {{ cart_item_count }}
+        {% cart_item_count %}
     """
-    request = context.get("request")
-    if request is None:
+    cart_id = _session_cart_id(context.get("request"))
+    if not cart_id:
         return 0
-    cart = Cart(request)
-    return cart.count()
+    total = Item.objects.filter(
+        cart_id=cart_id,
+        cart__checked_out=False,
+    ).aggregate(total=Sum("quantity"))["total"]
+    return total or 0
 
 
 @register.simple_tag(takes_context=True)
@@ -33,13 +56,16 @@ def cart_summary(context) -> str:
     Usage::
 
         {% load cart_tags %}
-        {{ cart_summary }}
+        {% cart_summary %}
     """
-    request = context.get("request")
-    if request is None:
+    cart_id = _session_cart_id(context.get("request"))
+    if not cart_id:
         return "$0.00"
-    cart = Cart(request)
-    return f"${cart.summary():.2f}"
+    total = Item.objects.filter(
+        cart_id=cart_id,
+        cart__checked_out=False,
+    ).aggregate(total=Sum(F("quantity") * F("unit_price")))["total"]
+    return f"${total or Decimal('0.00'):.2f}"
 
 
 @register.simple_tag(takes_context=True)
@@ -50,15 +76,15 @@ def cart_is_empty(context) -> bool:
     Usage::
 
         {% load cart_tags %}
-        {% if cart_is_empty %}
-            <p>Your cart is empty</p>
-        {% endif %}
+        {% cart_is_empty %}
     """
-    request = context.get("request")
-    if request is None:
+    cart_id = _session_cart_id(context.get("request"))
+    if not cart_id:
         return True
-    cart = Cart(request)
-    return cart.is_empty()
+    return not Item.objects.filter(
+        cart_id=cart_id,
+        cart__checked_out=False,
+    ).exists()
 
 
 @register.simple_tag(takes_context=True)
@@ -66,18 +92,28 @@ def cart_link(context, text: str = "View Cart", css_class: str = "") -> str:
     """
     Return an HTML link to the cart page.
 
+    When ``CART_DETAIL_URL_NAME`` is defined in settings, the URL is
+    resolved via :func:`django.urls.reverse`. Otherwise (and on a
+    ``NoReverseMatch``), the tag falls back to the static ``"/cart/"``
+    default so a misconfigured URL name doesn't break the surrounding
+    template render.
+
+    The cart's primary key is never embedded in the URL — pre-v3.0.13
+    the tag emitted ``/cart/{id}/`` and leaked sequential ids to
+    referrers, analytics, and third-party scripts (P1-C).
+
     Usage::
 
         {% load cart_tags %}
-        {{ cart_link "Go to Cart" "btn btn-primary" }}
+        {% cart_link "Go to Cart" "btn btn-primary" %}
     """
-    request = context.get("request")
-    if request is None:
-        cart_url = "/cart/"
-    else:
-        cart = Cart(request)
-        cart_id = request.session.get("CART-ID", "")
-        cart_url = f"/cart/{cart_id}/" if cart_id else "/cart/"
+    url_name = getattr(settings, "CART_DETAIL_URL_NAME", None)
+    cart_url = "/cart/"
+    if url_name:
+        try:
+            cart_url = reverse(url_name)
+        except NoReverseMatch:
+            pass
 
     if css_class:
         return format_html('<a href="{}" class="{}">{}</a>', cart_url, css_class, text)

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -171,3 +171,97 @@ def test_cart_link_renders_through_template_engine(db, rf_request):
 
     assert 'class="btn btn-primary"' in result
     assert '>My Cart</a>' in result
+
+
+# --------------------------------------------------------------------------- #
+# P1-C: template tags must NOT create Cart rows on pure-read renders.
+#
+# Before this fix every tag called ``Cart(request)`` unconditionally, which
+# materialises a DB row if the session has no CART-ID. Sites that load any
+# of these tags in a site-wide header created one abandoned cart per bot /
+# crawler / healthcheck pageview — the clean_carts cron became a firehose
+# and downstream projects had no ergonomic way to opt out.
+# See docs/ANALYSIS.md §4.4.
+# --------------------------------------------------------------------------- #
+
+from cart.models import Cart as CartModel  # noqa: E402
+
+
+def test_cart_item_count_on_fresh_session_creates_no_cart_row(db, rf_request):
+    assert CartModel.objects.count() == 0
+
+    result = cart_item_count(Context({"request": rf_request}))
+
+    assert result == 0
+    assert CartModel.objects.count() == 0
+
+
+def test_cart_summary_on_fresh_session_creates_no_cart_row(db, rf_request):
+    assert CartModel.objects.count() == 0
+
+    result = cart_summary(Context({"request": rf_request}))
+
+    assert result == "$0.00"
+    assert CartModel.objects.count() == 0
+
+
+def test_cart_is_empty_on_fresh_session_creates_no_cart_row(db, rf_request):
+    assert CartModel.objects.count() == 0
+
+    result = cart_is_empty(Context({"request": rf_request}))
+
+    assert result is True
+    assert CartModel.objects.count() == 0
+
+
+def test_cart_link_on_fresh_session_creates_no_cart_row(db, rf_request):
+    assert CartModel.objects.count() == 0
+
+    cart_link(Context({"request": rf_request}))
+
+    assert CartModel.objects.count() == 0
+
+
+# --------------------------------------------------------------------------- #
+# P1-C: cart_link URL hygiene
+# --------------------------------------------------------------------------- #
+
+def test_cart_link_does_not_expose_cart_id_in_url(cart, product, context_with_request):
+    """Sequential integer cart ids must not leak into the rendered URL.
+    The pre-fix ``/cart/{id}/`` shape exposed those ids to referrers,
+    analytics, and third-party scripts — a minor information disclosure
+    and a broken URL on any project that doesn't define the route.
+    """
+    cart.add(product, Decimal("10.00"))
+
+    result = cart_link(context_with_request)
+
+    assert f"/cart/{cart.cart.pk}/" not in result
+
+
+def test_cart_link_uses_reverse_when_CART_DETAIL_URL_NAME_is_set(
+    cart, context_with_request, settings
+):
+    """With ``CART_DETAIL_URL_NAME`` configured, the tag must resolve
+    the URL via ``reverse()`` instead of hardcoding ``/cart/``. The
+    test URL conf defines ``path("cart/", ..., name="cart_detail")``
+    so reversed output is ``/cart/`` — we assert the tag returned
+    exactly that, with no cart id suffix."""
+    settings.CART_DETAIL_URL_NAME = "cart_detail"
+
+    result = cart_link(context_with_request)
+
+    assert 'href="/cart/"' in result
+
+
+def test_cart_link_falls_back_to_slash_cart_when_reverse_raises(
+    cart, context_with_request, settings
+):
+    """A misconfigured URL name (name doesn't resolve) must degrade to
+    the static ``/cart/`` default rather than raising and breaking the
+    surrounding template render."""
+    settings.CART_DETAIL_URL_NAME = "not_a_real_url"
+
+    result = cart_link(context_with_request)
+
+    assert 'href="/cart/"' in result


### PR DESCRIPTION
## Summary

P1-C from [`docs/ANALYSIS.md`](docs/ANALYSIS.md) §4.4.

Before this PR, every render of any cart template tag called `Cart(request)` unconditionally, which materialises a DB row on a fresh visitor. A site-wide header using any of these tags created **one abandoned cart per bot, crawler, healthcheck, and anonymous pageview**. `cart_link` also embedded the cart's integer primary key in the anchor URL (`/cart/{id}/`) — leaking sequential DB ids to referrers/analytics/third-party scripts and 404'ing on any project that doesn't define that URL shape (the library ships no such view).

### Fixes

**Three read-only tags** (`cart_item_count`, `cart_summary`, `cart_is_empty`): look up `CART-ID` in the session, query `cart_item` directly when present, return defaults otherwise. No `Cart` facade, no row materialisation. Shared `_session_cart_id` helper captures the session-lookup contract.

**`cart_link`**: drop the `/cart/{id}/` URL shape entirely. Resolve the anchor via `reverse(CART_DETAIL_URL_NAME)` when the new setting is defined; fall back to a static `/cart/` when unset or on `NoReverseMatch`. The tag never queries the cart at all.

## TDD

Seven new assertions in `tests/test_templatetags.py` — all fail on master for the exact reasons ANALYSIS §4.4 predicts:

- 4× `test_<tag>_on_fresh_session_creates_no_cart_row` — master leaves a row behind; branch leaves the table empty.
- `test_cart_link_does_not_expose_cart_id_in_url` — master renders `/cart/{pk}/`; branch doesn't.
- `test_cart_link_uses_reverse_when_CART_DETAIL_URL_NAME_is_set` — master ignores the setting.
- `test_cart_link_falls_back_to_slash_cart_when_reverse_raises` — master ignores the setting entirely; branch handles `NoReverseMatch` cleanly.

## Test plan

- [x] Default suite: `uv run pytest` → 312 passed (305 + 7 new).
- [x] Custom-user suite: `uv run pytest --ds=tests.settings_custom_user tests/test_cart_custom_user.py` → 4 passed.
- [x] Existing template-tag tests (including end-to-end template-engine renders) still pass.
- [x] README Template Tags section updated with a no-side-effect callout + `CART_DETAIL_URL_NAME` example; Settings Reference table adds the new setting row.

## Notes for reviewer

- No version bump — stays in `[Unreleased]`.
- No new dependency; no migration.
- Public contract of the tags is unchanged (same signatures, same returns). The only observable difference for downstream: fewer rows in `cart_cart` after crawler traffic, and `/cart/{id}/` anchors disappear from rendered HTML.
- Next (and last P1): P1-D (`cart_serializable` / `from_serializable` collide on `object_id` across content types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)