### PR TITLE
chore(release): v3.0.13 — P1 wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+## [3.0.13] — 2026-04-21
+
 ### Added
 - `tests/test_readme.py` — link-integrity checks for `README.md`.
   Fails CI if any relative repo path or intra-doc `#anchor` goes dead.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-cart"
-version = "3.0.12"
+version = "3.0.13"
 authors = [
   { name="Bruno Mentges de Carvalho", email="bruno@mentgesinformatica.com.br" },
 ]


### PR DESCRIPTION
## Summary

Release PR — cuts v3.0.13 with all four P1 correctness fixes plus surrounding hygiene. No new code: just finalises the `[Unreleased]` section under a dated heading and bumps `pyproject.toml`.

## What's shipping

- **P1-A** (#72) — `Cart.checkout()` idempotent across facades; `SELECT … FOR UPDATE` on the `Cart` row.
- **P1-B** (#73) — `Cart.user` uses `settings.AUTH_USER_MODEL`; library installs cleanly on custom-user-model projects. Dedicated custom-user CI leg.
- **P1-C** (#74) — Template tags no longer create abandoned Cart rows; `cart_link` drops `/cart/{id}/`, adds `CART_DETAIL_URL_NAME` setting.
- **P1-D** (#75) — `cart_serializable` / `from_serializable` key by `"<ct_id>:<object_id>"` composites; legacy payloads still restore.
- **README link validator** (#72) + **Py3.14×Django<6 CI matrix hygiene** (#71) + **custom-AUTH_USER_MODEL CI leg** (#73) landed alongside.

## Test plan

- [x] `uv run pytest` → **315 passed**.
- [x] `uv run pytest --ds=tests.settings_custom_user tests/test_cart_custom_user.py` → **4 passed**.
- [x] CHANGELOG has `## [3.0.13] — 2026-04-21` section for the changelog-gate CI job to match against `pyproject.toml` `version = "3.0.13"`.

## After merge

Tag `v3.0.13` on the merge commit and push — the CI publish job (gated on `refs/tags/v*`) uploads to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)