### PR TITLE
fix(P2): reject PERCENT discount value > 100 + clamp calculate_discount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Fixed
+- **P2** · `DiscountType.PERCENT` no longer lets `value` exceed 100.
+  `Discount.clean()` now raises `ValidationError` on percentage
+  discounts with `value > 100`, which admin forms and any caller
+  going through `full_clean()` will surface before save.
+  `Discount.calculate_discount()` also clamps its return value to
+  the cart subtotal (matching the existing clamp on `FIXED`
+  discounts), so legacy rows that pre-date the guard can't produce
+  a discount larger than the cart is worth. A DB-level
+  `CheckConstraint` is not added — the `check=` / `condition=`
+  kwarg renamed between Django 5.0 and 6.0 and the supported
+  matrix spans both; the constraint will follow once 4.2 rolls off.
 
 ## [3.0.13] — 2026-04-21
 

--- a/cart/models.py
+++ b/cart/models.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models
 from django.db.models import F
@@ -213,19 +214,51 @@ class Discount(models.Model):
 
         return True, ""
 
+    def clean(self) -> None:
+        """Validate cross-field invariants.
+
+        - A ``PERCENT`` discount cannot claim more than 100% off.
+          Django admin forms and any caller using ``full_clean()``
+          before ``save()`` rejects such rows before they reach the DB.
+          The guard is not a DB ``CheckConstraint`` because the
+          ``CheckConstraint(check=…)`` / ``CheckConstraint(condition=…)``
+          kwarg renamed between Django 5.0 and 6.0, and the project's
+          supported matrix spans both. Once 4.2 drops off the matrix,
+          a DB-level constraint can be added without compat pain.
+        """
+        super().clean()
+        if (
+            self.discount_type == DiscountType.PERCENT
+            and self.value is not None
+            and self.value > Decimal("100")
+        ):
+            raise ValidationError({
+                "value": _(
+                    "Percentage discounts cannot exceed 100% — "
+                    "value must be between 0 and 100."
+                ),
+            })
+
     def calculate_discount(self, cart: "Cart") -> Decimal:
         """Calculate the discount amount for the given cart.
-        
+
+        The returned amount is always clamped to the cart's subtotal so
+        a misconfigured ``PERCENT`` discount (``value > 100`` — possible
+        on legacy rows that pre-date the :meth:`clean` guard) can't
+        produce a discount larger than what the cart is worth.
+
         Args:
             cart: The cart to calculate discount for.
-            
+
         Returns:
-            The discount amount as a Decimal.
+            The discount amount as a Decimal, never exceeding
+            ``cart.summary()``.
         """
+        subtotal = cart.summary()
         if self.discount_type == DiscountType.PERCENT:
-            return (cart.summary() * self.value) / Decimal("100")
-        else:
-            return min(self.value, cart.summary())
+            amount = (subtotal * self.value) / Decimal("100")
+            return min(amount, subtotal)
+        return min(self.value, subtotal)
 
     def increment_usage(self) -> None:
         """Atomically increment the usage counter by one.

--- a/tests/test_discount_model.py
+++ b/tests/test_discount_model.py
@@ -111,6 +111,73 @@ def test_fixed_discount_cannot_exceed_cart_subtotal(cart_worth_200):
     assert discount.calculate_discount(cart_worth_200) == Decimal("200.00")
 
 
+def test_percent_discount_amount_cannot_exceed_cart_subtotal(cart_worth_200):
+    """P2 regression: a ``PERCENT`` discount with ``value > 100`` must
+    still never return more than the cart's subtotal.
+
+    Before v3.0.14, ``calculate_discount`` computed
+    ``summary * value / 100`` with no clamp, so a (mis)configured
+    150%-off discount on a $200 cart yielded a $300 discount amount —
+    nonsense for any UI displaying "You saved $X" that doesn't also
+    call :meth:`Cart.total`. ``FIXED`` already clamped via ``min``;
+    ``PERCENT`` now matches. See docs/ANALYSIS.md §0 (P2 list).
+    """
+    discount = Discount.objects.create(
+        code="BIGPCT",
+        discount_type=DiscountType.PERCENT,
+        value=Decimal("150.00"),
+    )
+
+    assert discount.calculate_discount(cart_worth_200) == Decimal("200.00")
+
+
+# --------------------------------------------------------------------------- #
+# clean() — PERCENT discounts can't exceed 100%
+# --------------------------------------------------------------------------- #
+
+def test_full_clean_rejects_percent_discount_value_above_100():
+    """Admin forms and any caller that goes through ``full_clean``
+    (Django's standard pre-save validation hook) must reject a
+    percentage discount that claims to take more than 100% off.
+    """
+    from django.core.exceptions import ValidationError
+
+    discount = Discount(
+        code="BAD_PCT",
+        discount_type=DiscountType.PERCENT,
+        value=Decimal("150.00"),
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        discount.full_clean()
+    assert "value" in exc.value.message_dict
+    assert "100" in str(exc.value.message_dict["value"])
+
+
+def test_full_clean_accepts_percent_discount_value_exactly_100():
+    """100% off = cart is free. That's a legitimate promo and must
+    pass validation."""
+    discount = Discount(
+        code="FREE",
+        discount_type=DiscountType.PERCENT,
+        value=Decimal("100.00"),
+    )
+
+    discount.full_clean()  # must not raise
+
+
+def test_full_clean_accepts_fixed_discount_value_above_100():
+    """The PERCENT ≤ 100 guard must not leak into FIXED discounts —
+    a $500 off voucher is a perfectly normal configuration."""
+    discount = Discount(
+        code="BIG_FIXED",
+        discount_type=DiscountType.FIXED,
+        value=Decimal("500.00"),
+    )
+
+    discount.full_clean()  # must not raise
+
+
 # --------------------------------------------------------------------------- #
 # is_valid_for_cart
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

First P2 from [`docs/ANALYSIS.md`](docs/ANALYSIS.md) §0.

`DiscountType.PERCENT` previously accepted any `value` (≥ 0 thanks to `MinValueValidator`). A misconfigured 150%-off discount on a $200 cart produced `Discount.calculate_discount(cart) == Decimal("300.00")` — `Cart.total()` masked the damage via `max(total, 0)` but any UI reading `cart.discount_amount()` directly rendered nonsense. `FIXED` discounts already clamped via `min(value, summary)`; `PERCENT` didn't.

### Fix

1. **`Discount.clean()`** raises `ValidationError` keyed on `value` when a `PERCENT` discount claims more than 100% off. Django admin forms + any `full_clean()` caller catches the bad config before save.
2. **`Discount.calculate_discount()`** clamps `PERCENT` amounts to `cart.summary()` — matches the pre-existing `FIXED` clamp. Defense-in-depth against legacy rows that pre-date the guard.

**No DB-level `CheckConstraint`**: the `check=` → `condition=` kwarg renamed between Django 5.0 and 6.0, and the supported matrix spans both. Hand-rolling the migration across versions would require kwarg-switch gymnastics. Deferring until 4.2 rolls off the matrix.

## TDD

- `test_percent_discount_amount_cannot_exceed_cart_subtotal` — master returns `300.00` (150% of 200); branch returns `200.00`.
- `test_full_clean_rejects_percent_discount_value_above_100` — master: `DID NOT RAISE`; branch: `ValidationError` on `value`.
- Boundary + FIXED-isolation tests (value=100 accepted, FIXED value above 100 accepted) lock the invariant surface.

## Test plan

- [x] `uv run pytest` → **319 passed** (315 + 4 new).
- [x] `uv run pytest --ds=tests.settings_custom_user tests/test_cart_custom_user.py` → **4 passed**.

## Notes for reviewer

- No version bump — stays in `[Unreleased]`.
- No migration (no schema change; just Python-level validation + arithmetic clamp).
- Contract summary for callers: `Discount.calculate_discount(cart)` is now guaranteed `0 ≤ amount ≤ cart.summary()` for both types.
- Next in the P2 queue: `valid_from < valid_until` invariant, `cart_serializable()` omits applied discount + user binding, decimal rounding in `Cart.total()` — let me know if you want them in a specific order or bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)