### PR TITLE
chore(release): v3.0.14 — P2 polish wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+## [3.0.14] — 2026-04-21
+
 ### Fixed
 - **P2** · `DiscountType.PERCENT` no longer lets `value` exceed 100.
   `Discount.clean()` now raises `ValidationError` on percentage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-cart"
-version = "3.0.13"
+version = "3.0.14"
 authors = [
   { name="Bruno Mentges de Carvalho", email="bruno@mentgesinformatica.com.br" },
 ]


### PR DESCRIPTION
## Summary

Release PR — cuts v3.0.14 with the six P2 fixes landed since v3.0.13. No new code: finalises the `[Unreleased]` section under a dated heading and bumps `pyproject.toml`.

## What's shipping

- **P2 PERCENT cap** (#77) — `Discount.clean()` rejects `PERCENT` with `value > 100`; `calculate_discount()` clamps to `cart.summary()` matching `FIXED`.
- **P2 bundle** (#78) — five fixes in one unit:
  - P2a — `valid_from > valid_until` rejected by `Discount.clean()`.
  - P2b — applied discount round-trips through `cart_serializable()` / `from_serializable()` via reserved `__discount__` key.
  - P2c — `Cart.total()` quantizes to 2dp with `ROUND_HALF_UP`.
  - P2d — `CartAdmin.search_fields=("=id",)` + hardened vacuous test.
  - P2e — `RuntimeWarning` from the three calculator factories on bad `CART_*_CLASS` dotted paths.

## Test plan

- [x] `uv run pytest` → **328 passed**.
- [x] `uv run pytest --ds=tests.settings_custom_user tests/test_cart_custom_user.py` → **4 passed**.
- [x] CHANGELOG has `## [3.0.14] — 2026-04-21` for the changelog-gate CI job.

## After merge

Tag `v3.0.14` on the merge commit and push — CI publish job uploads to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)