### PR TITLE
fix(P3 bundle): schema polish + safer get_user_carts + default_app_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CART_TAX_CALCULATOR` silently produced "tax is always 0.00"
   at runtime. The session-adapter factory is still the strict
   exception — it raises loudly, unchanged.
+- **P3** · `Item.quantity` gets a `MinValueValidator(1)` so
+  `full_clean()` rejects `quantity=0` — aligning the DB layer with
+  the `Cart.add()` / `Cart.update()` API contract. Direct
+  `Item.objects.create(..., quantity=0)` still slips through (DB
+  `CHECK` constraint deferred alongside the other Discount
+  invariants — Django 4.2/6.0 `check=`/`condition=` kwarg rename).
+- **P3** · `Cart.checked_out` and `Cart.creation_date` gain
+  `db_index=True`. The `clean_carts` management command filters on
+  both; without an index, each run fell back to a sequential scan
+  that bit at tens-of-thousands-of-rows scale.
+
+### Added
+- `Cart.get_active_user_carts(user)` classmethod — pre-filters
+  `checked_out=False`. Login-merge flows should prefer this over
+  `get_user_carts(user)` (which returns the full history including
+  past orders). The footgun of forgetting the filter — silently
+  resurrecting a past order's items into the fresh guest cart — is
+  gone by design.
+
+### Removed
+- `cart/__init__.py` no longer declares `default_app_config`. The
+  attribute was deprecated in Django 3.2 and removed in Django 6.0;
+  `cart.apps.CartConfig` is auto-discovered from `apps.py`.
+
+### Docs
+- README login-flow example uses `get_active_user_carts()`. A callout
+  distinguishes it from `get_user_carts()` (order history).
 
 ## [3.0.13] — 2026-04-21
 

--- a/README.md
+++ b/README.md
@@ -302,9 +302,7 @@ from cart.cart import Cart
 
 def on_login(request):
     guest = Cart(request)                 # the current session cart
-    prior = Cart.get_user_carts(request.user).filter(
-        checked_out=False,
-    ).first()
+    prior = Cart.get_active_user_carts(request.user).first()
 
     if prior is None:
         guest.bind_to_user(request.user)
@@ -314,6 +312,13 @@ def on_login(request):
     user_cart.cart = prior
     user_cart.merge(guest, strategy="add")   # or "replace" / "keep_higher"
 ```
+
+> [!note] `get_user_carts()` vs `get_active_user_carts()`
+> Use `get_active_user_carts(user)` for login-merge flows — it pre-filters
+> `checked_out=False`, so a forgotten `.filter(…)` can't silently
+> resurrect items from a past order. Use `get_user_carts(user)` when
+> you genuinely need every cart the user has ever had (order history,
+> admin dashboards).
 
 Available merge strategies:
 

--- a/cart/__init__.py
+++ b/cart/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "cart.apps.CartConfig"

--- a/cart/cart.py
+++ b/cart/cart.py
@@ -602,12 +602,33 @@ class Cart:
     @classmethod
     def get_user_carts(cls, user) -> QuerySet[models.Cart]:
         """
-        Get all carts associated with a user.
+        Get all carts associated with a user — **including** already
+        checked-out carts. Use this when you need the full history
+        (order list, admin view). For login-time merge flows, prefer
+        :meth:`get_active_user_carts` — the header-filter footgun is
+        skipped by design.
 
         :param user: Django User model instance.
-        :returns: QuerySet of Cart objects.
+        :returns: QuerySet of Cart objects (ordered by ``-creation_date``).
         """
         return models.Cart.objects.filter(user=user)
+
+    @classmethod
+    def get_active_user_carts(cls, user) -> QuerySet[models.Cart]:
+        """
+        Get the user's non-checked-out carts — the carts that can
+        still be mutated or merged.
+
+        Intended for login-time merge flows where forgetting the
+        ``checked_out=False`` filter (a documented footgun on
+        :meth:`get_user_carts`) would resurrect a past order's items
+        into the fresh guest cart. ``get_active_user_carts`` hard-codes
+        the filter so the correct path is the obvious one.
+
+        :param user: Django User model instance.
+        :returns: QuerySet of Cart objects with ``checked_out=False``.
+        """
+        return models.Cart.objects.filter(user=user, checked_out=False)
 
     def add_bulk(self, items: list[dict]) -> list[models.Item]:
         """

--- a/cart/migrations/0006_indexes_and_quantity_validator.py
+++ b/cart/migrations/0006_indexes_and_quantity_validator.py
@@ -1,0 +1,57 @@
+"""Schema polish: index clean_carts filter columns + gate Item.quantity ≥ 1.
+
+``cart.models.Cart.checked_out`` and ``Cart.creation_date`` gain
+``db_index=True``. The ``clean_carts`` management command filters on
+both (``creation_date__lt=cutoff AND checked_out=False``) and does so
+on potentially-large tables; without an index each invocation falls
+back to a sequential scan. SQLite and every production backend we
+support handles ``db_index=True`` identically.
+
+``cart.models.Item.quantity`` gains ``MinValueValidator(1)``. The
+:class:`cart.cart.Cart` API already rejected ``quantity < 1`` at
+``.add()`` / ``.update()`` but a direct
+``Item.objects.create(..., quantity=0)`` bypassed that contract; now
+``full_clean()`` catches the mismatch. A DB-level ``CHECK`` is not
+added here — the ``CheckConstraint(check=…)`` / ``…(condition=…)``
+kwarg renamed between Django 5.0 and 6.0 and the supported matrix
+spans both; the DB constraint will follow once 4.2 drops off.
+"""
+import django.utils.timezone
+from django.core.validators import MinValueValidator
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cart", "0005_add_discount_model"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="cart",
+            name="checked_out",
+            field=models.BooleanField(
+                db_index=True,
+                default=False,
+                verbose_name="checked out",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="cart",
+            name="creation_date",
+            field=models.DateTimeField(
+                db_index=True,
+                default=django.utils.timezone.now,
+                verbose_name="creation date",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="item",
+            name="quantity",
+            field=models.PositiveIntegerField(
+                validators=[MinValueValidator(1)],
+                verbose_name="quantity",
+            ),
+        ),
+    ]

--- a/cart/models.py
+++ b/cart/models.py
@@ -19,10 +19,12 @@ class Cart(models.Model):
     creation_date: models.DateTimeField = models.DateTimeField(
         verbose_name=_("creation date"),
         default=timezone.now,
+        db_index=True,
     )
     checked_out: models.BooleanField = models.BooleanField(
         default=False,
         verbose_name=_("checked out"),
+        db_index=True,
     )
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -78,7 +80,10 @@ class Item(models.Model):
         on_delete=models.CASCADE,
         related_name="items",
     )
-    quantity: int = models.PositiveIntegerField(verbose_name=_("quantity"))
+    quantity: int = models.PositiveIntegerField(
+        verbose_name=_("quantity"),
+        validators=[MinValueValidator(1)],
+    )
     unit_price: Decimal = models.DecimalField(
         max_digits=18,
         decimal_places=2,

--- a/tests/test_cart_user_binding.py
+++ b/tests/test_cart_user_binding.py
@@ -56,3 +56,54 @@ def test_user_can_have_multiple_carts(cart, other_cart, product_factory, django_
     carts = Cart.get_user_carts(user)
 
     assert carts.count() == 2
+
+
+# --------------------------------------------------------------------------- #
+# get_active_user_carts — P3: safer default for login-flow merge
+# --------------------------------------------------------------------------- #
+
+def test_get_active_user_carts_excludes_checked_out_carts(
+    cart, other_cart, product, django_user_model
+):
+    """P3 regression: ``Cart.get_user_carts`` returns every cart
+    associated with a user — including already-checked-out ones.
+    The README's login-flow example filters on ``.filter(checked_out=False)``
+    on top, but downstream callers that forget the filter will merge
+    an already-checked-out cart (a past order) into the fresh guest
+    cart, resurrecting old items. ``get_active_user_carts`` hard-codes
+    the filter so the safer path is the obvious one."""
+    user = django_user_model.objects.create_user(
+        username="mergeuser",
+        email="m@example.com",
+        password="p",
+    )
+    cart.bind_to_user(user)
+    cart.add(product, Decimal("10.00"))
+    cart.checkout()
+
+    other_cart.bind_to_user(user)
+    other_cart.add(product, Decimal("10.00"))
+
+    active = Cart.get_active_user_carts(user)
+
+    assert active.count() == 1
+    assert active.first().pk == other_cart.cart.pk
+
+
+def test_get_user_carts_still_includes_checked_out_carts_for_back_compat(
+    cart, product, django_user_model
+):
+    """get_user_carts() is unchanged — callers that genuinely want
+    all carts (e.g. building an order-history view) keep working."""
+    user = django_user_model.objects.create_user(
+        username="historyuser",
+        email="h@example.com",
+        password="p",
+    )
+    cart.bind_to_user(user)
+    cart.add(product, Decimal("10.00"))
+    cart.checkout()
+
+    all_carts = Cart.get_user_carts(user)
+
+    assert all_carts.count() == 1

--- a/tests/test_item_model.py
+++ b/tests/test_item_model.py
@@ -154,6 +154,46 @@ def test_positive_unit_price_passes_validation(product):
 
 
 # --------------------------------------------------------------------------- #
+# quantity validation (P3 — align DB-layer check with Cart API contract)
+# --------------------------------------------------------------------------- #
+
+def test_zero_quantity_fails_validation(product):
+    """``Cart.add`` already rejects ``quantity < 1`` at the API
+    boundary. The Item model's ``PositiveIntegerField`` allowed 0 —
+    direct ``Item.objects.create(..., quantity=0)`` bypassed the Cart
+    guard. ``full_clean()`` now catches the mismatch in admin forms
+    and any caller that validates before save."""
+    cart = CartModel.objects.create()
+    ct = ContentType.objects.get_for_model(FakeProduct)
+    item = Item(
+        cart=cart,
+        content_type=ct,
+        object_id=product.pk,
+        unit_price=Decimal("10.00"),
+        quantity=0,
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        item.full_clean()
+
+    assert "quantity" in exc_info.value.message_dict
+
+
+def test_positive_quantity_passes_validation(product):
+    cart = CartModel.objects.create()
+    ct = ContentType.objects.get_for_model(FakeProduct)
+    item = Item(
+        cart=cart,
+        content_type=ct,
+        object_id=product.pk,
+        unit_price=Decimal("10.00"),
+        quantity=1,
+    )
+
+    item.full_clean()  # must not raise
+
+
+# --------------------------------------------------------------------------- #
 # Cross-cart uniqueness
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
## Summary

Four P3 items from [`docs/ANALYSIS.md`](docs/ANALYSIS.md) §0, bundled for review velocity per the P2 pattern.

| # | What | Where |
|---|------|-------|
| **P3a** | Drop `default_app_config = "cart.apps.CartConfig"` — deprecated in Django 3.2, removed in 6.0 | `cart/__init__.py` |
| **P3b** | `Item.quantity` gains `MinValueValidator(1)` so `full_clean()` rejects `quantity=0`, aligning the DB layer with the existing `Cart.add()`/`update()` API contract | `cart/models.py`, migration `0006` |
| **P3c** | `db_index=True` on `Cart.checked_out` and `Cart.creation_date` — `clean_carts` filters on both | `cart/models.py`, migration `0006` |
| **P3d** | New `Cart.get_active_user_carts(user)` classmethod — pre-filters `checked_out=False`; README login-flow example switched to it | `cart/cart.py`, `README.md` |

## TDD

- `test_zero_quantity_fails_validation` — master: `DID NOT RAISE`; branch: `ValidationError` keyed on `quantity`.
- `test_get_active_user_carts_excludes_checked_out_carts` — master: `AttributeError` (method doesn't exist); branch: returns only the active cart.
- `test_get_user_carts_still_includes_checked_out_carts_for_back_compat` — codifies the existing contract so it doesn't drift.

## Test plan

- [x] `uv run pytest` → **332 passed** (328 + 4 new / adjusted).
- [x] `uv run pytest --ds=tests.settings_custom_user tests/test_cart_custom_user.py` → **4 passed**.
- [x] Migration `0006_indexes_and_quantity_validator.py` applies cleanly under pytest-django's DB setup.

## Merge order note

This PR was branched from master *before* the v3.0.14 release PR #79 landed. After #79 merges, the CHANGELOG `[Unreleased]` section here will conflict with the release's move of those items under `[3.0.14]`. Happy to rebase and resolve — I'll push a fixup once you merge #79 (or just merge this after #79 and let the conflict resolution be my problem).

## Notes for reviewer

- `get_user_carts(user)` is intentionally left as-is (returns all carts). A default-change would break anyone consuming it for order history. The new `get_active_user_carts` is additive.
- `default_app_config` removal is safe on Django ≥ 3.2; Django 6.0 already ignores it. Verified via full suite green.
- No DB-level `CHECK` constraints added for `Item.quantity ≥ 1` — same `check=`/`condition=` kwarg rename that blocked the Discount invariants. Deferred uniformly.
- Remaining from ANALYSIS §0: `can_checkout()` enforcement in `checkout()` (3.1.0 breaking), plus the pre-commit hook version refresh and dependabot coverage — both CI/tooling concerns deserving their own dedicated pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)