### PR TITLE
perf: Cart.items_with_products() batch loader — kills the Item.product N+1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+- `Cart.items_with_products()` — batch-prefetching iteration path.
+  Loads items with `select_related('content_type')`, groups by
+  content type, and `in_bulk` fetches the product rows per type,
+  populating `Item._product_cache` so downstream `.product` access
+  is a pure in-memory read. A 100-item cart split across 3 product
+  models drops from ~100 queries (plain `for item in cart` + per-item
+  `.product` access) to 4. Plain iteration remains unchanged and is
+  still the right call when you don't read `.product`. Items whose
+  underlying product row was deleted are left un-prefetched so the
+  existing `DoesNotExist`-on-first-access semantic is preserved.
+
+### Docs
+- README "Iteration and introspection" section adds a callout
+  distinguishing plain iteration from `items_with_products()` for
+  line-item renders.
 
 ## [3.0.14] — 2026-04-21
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,23 @@ for item in cart: ...     # iterates items, content_type preloaded
 Each `item` exposes `.product`, `.quantity`, `.unit_price`,
 `.total_price` (a `Decimal` property).
 
+> [!tip] Avoid the N+1 when rendering line-item tables
+> Plain iteration (`for item in cart`) leaves `item.product` as a
+> lazy property — touching `.product` on each item in a template
+> issues one SELECT per item. For render paths that read the
+> concrete product (name, image, SKU), use
+> `cart.items_with_products()`:
+>
+> ```python
+> for item in cart.items_with_products():
+>     # item.product is already prefetched — zero extra queries.
+>     ...
+> ```
+>
+> Batches products by content type under the hood: one SELECT on
+> `Item` plus one `in_bulk` per distinct product model. A 100-item
+> cart split across 3 product models drops from ~100 queries to 4.
+
 ### Money math
 
 ```python

--- a/cart/cart.py
+++ b/cart/cart.py
@@ -198,6 +198,51 @@ class Cart:
     def __contains__(self, product):
         return self._get_item(product) is not None
 
+    def items_with_products(self) -> list[models.Item]:
+        """Return the cart's items with their ``.product`` attribute prefetched.
+
+        Plain iteration (``for item in cart``) loads the items with their
+        content types but leaves ``Item.product`` as a lazy property — a
+        50-item cart then issues 50 ``SELECT`` statements when the
+        caller iterates and touches ``.product`` (classic N+1).
+
+        This method batches the product lookups: one ``SELECT`` on
+        ``Item`` (with ``select_related('content_type')``) plus one
+        ``in_bulk`` per distinct content type. A 100-item cart split
+        across 3 product models drops from ~100 queries to 4. Items
+        whose underlying product row was deleted are left un-prefetched
+        so the existing ``.product`` ``DoesNotExist`` semantic is
+        preserved on that first access.
+
+        Use this method when you iterate the cart and read the concrete
+        product — templates rendering a line-item table are the common
+        case. Plain iteration is fine when you only read ``.quantity``,
+        ``.unit_price``, or ``.total_price``.
+
+        Returns:
+            A list of :class:`cart.models.Item` with ``.product``
+            pre-cached on each item (where the row still exists).
+        """
+        from collections import defaultdict
+
+        items = list(self.cart.items.select_related("content_type").all())
+        items_by_ct: dict = defaultdict(list)
+        for item in items:
+            items_by_ct[item.content_type].append(item)
+
+        for content_type, grouped in items_by_ct.items():
+            ids = [i.object_id for i in grouped]
+            products_by_id = content_type.model_class().objects.in_bulk(ids)
+            for item in grouped:
+                product = products_by_id.get(item.object_id)
+                if product is not None:
+                    item._product_cache = product
+                # else: leave _product_cache unset — Item.product will
+                # hit the DB on first access and raise DoesNotExist,
+                # matching the plain-iteration contract.
+
+        return items
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -84,3 +84,58 @@ def test_iteration_is_query_bounded_independent_of_item_count(
         items = list(cart)
 
     assert len(items) == 50
+
+
+def test_items_with_products_accessing_product_is_query_free(
+    cart, product_factory, django_assert_max_num_queries
+):
+    """``items_with_products()`` must prefetch every item's product
+    row so subsequent ``.product`` access is a pure in-memory read.
+
+    Shape: 1 SELECT on Item (select_related content_type) + 1 SELECT
+    per distinct content type. 50 items all from the ``FakeProduct``
+    model = 1 content type = 2 queries total. The upper bound of 2
+    catches any regression that falls back to the per-item
+    ``.content_type.model_class().objects.get(pk=...)`` path (which
+    would be 50 extra queries).
+    """
+    for i in range(50):
+        cart.add(product_factory(name=f"BatchIter{i}"), Decimal("10.00"))
+
+    cart._invalidate_cache()
+
+    with django_assert_max_num_queries(2):
+        items = cart.items_with_products()
+        for item in items:
+            _ = item.product  # must be cache hit
+
+    assert len(items) == 50
+
+
+def test_items_with_products_batches_per_content_type(
+    cart, django_assert_max_num_queries
+):
+    """Items from multiple product models should require exactly one
+    product-table query per distinct content type, not one per item."""
+    from tests.test_app.models import FakeProduct, FakeProductNoPrice
+
+    for i in range(5):
+        cart.add(
+            FakeProduct.objects.create(name=f"A{i}", price=Decimal("1.00")),
+            Decimal("1.00"),
+        )
+    for i in range(5):
+        cart.add(
+            FakeProductNoPrice.objects.create(name=f"B{i}"),
+            Decimal("2.00"),
+        )
+
+    cart._invalidate_cache()
+
+    # 1 SELECT Item (with content_type) + 2 SELECT product tables = 3.
+    with django_assert_max_num_queries(3):
+        items = cart.items_with_products()
+        for item in items:
+            _ = item.product
+
+    assert len(items) == 10


### PR DESCRIPTION
## Summary

[`docs/ANALYSIS.md`](docs/ANALYSIS.md) §8.1 flagged the per-item `Item.product` fetch inside cart iteration as **"the single highest-impact optimization the library can ship."** `Cart.__iter__` already `select_related`'s `content_type`, but `item.product` is a lazy property that calls `content_type.model_class().objects.get(pk=...)` on each access — a 50-item cart issues 50 extra `SELECT`s when a template renders the product name.

`Cart.items_with_products()` is a new, **additive** iteration path that batches the product lookups per content type:

- 1 `SELECT` on `Item` (with `select_related('content_type')`)
- 1 `in_bulk` per distinct content type

A 100-item cart split across 3 product models drops from ~100 queries to 4.

`Cart.__iter__` is unchanged — consumers that don't touch `.product` keep their current zero-product-query profile.

## TDD

- `test_items_with_products_accessing_product_is_query_free` — 50 items in a single content type; iterates and touches `.product` on each. Bound at **≤ 2 queries** (master would be 51+).
- `test_items_with_products_batches_per_content_type` — 5 items in each of 2 content types. Bound at **≤ 3 queries** (master would be 11+).
- Both failed on master with `AttributeError` (method doesn't exist); both green post-fix.

## Design notes

- Items whose underlying product row has been deleted are left un-prefetched so the existing `DoesNotExist`-on-first-`.product`-access semantic is preserved. Consumers that care about missing products keep the same exception path.
- The method returns a **list**, not a generator, so `len(result)` and index access work naturally (consumers often want this for pagination and tests). The memory cost is O(N items) which is what plain `list(cart)` already produces.
- No change to the model layer — the prefetch happens inside the facade via `in_bulk`. Avoids coupling `Item` to a prefetch mechanism that would then need `Prefetch` objects per GenericFK.

## Test plan

- [x] `uv run pytest` → **334 passed** (332 + 2 new).
- [x] `uv run pytest --ds=tests.settings_custom_user tests/test_cart_custom_user.py` → **4 passed**.
- [x] README "Iteration and introspection" callout points users at the new method for line-item render paths.

## Notes for reviewer

- No version bump (stays in `[Unreleased]`).
- No migration.
- Not breaking — `Cart.__iter__` signature and query profile unchanged.
- Next candidates: CI/tooling pass (pre-commit refresh + dependabot + lint job), or v3.1.0 scope (`can_checkout()` enforcement + the deprecation rename `CARTS_SESSION_ADAPTER_CLASS` → `CART_SESSION_ADAPTER`). Let me know preferred direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)