### PR TITLE
chore(typing): reintroduce mypy with django-stubs on Py3.12×Django 5.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,16 @@ repos:
     hooks:
       - id: flake8
         args: ["--max-line-length=100", "--extend-ignore=E203,W503,E501"]
+  # mypy runs on a single type-check cell (Py3.12 × Django 5.1) via the
+  # additional_dependencies pin below. django-stubs is tied to specific
+  # Django minors and the type-check signal doesn't materially vary
+  # across the rest of the test matrix, so one cell is the industry-
+  # standard tradeoff. See pyproject.toml [tool.mypy] for scope.
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.20.0
+    hooks:
+      - id: mypy
+        files: ^cart/
+        additional_dependencies:
+          - "django-stubs[compatible-mypy]>=5.1"
+          - "Django>=5.1,<5.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,18 +24,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inline in the Actions log.
 - Dependabot now covers the `pre-commit` ecosystem (weekly). Hook
   revs stay current without manual bump PRs.
+- **mypy** is back in pre-commit (and therefore in the CI `Lint`
+  job), this time with `django-stubs[compatible-mypy]` so the Django
+  ORM actually type-checks. Scope is `cart/` only — `tests/` is
+  deliberately excluded (signal-light for type-check cost). Runs on
+  one cell (Py3.12 × Django 5.1) via the hook's
+  `additional_dependencies` pin; django-stubs is tied to specific
+  Django minors and the type-check signal barely varies across the
+  rest of the matrix, so one cell is the industry-standard tradeoff.
+  Starting configuration is `strict = false` with
+  `check_untyped_defs = true` — a pragmatic starting point that
+  catches real bugs without forcing a whole-codebase annotation
+  sweep. Follow-ups can ratchet strictness per module.
 
 ### Changed
 - Pre-commit hook versions refreshed (`pre-commit-hooks` v4.5.0 →
   v5.0.0 adds `check-yaml` / `check-toml` / `check-merge-conflict`;
   `black` 24.1.0 → 24.10.0; `isort` 5.13.0 → 5.13.2 with
   `--profile=black`; `flake8` 7.0.0 → 7.1.1 with `max-line-length=100`
-  and `E203`/`W503`/`E501` ignored for black-compat). `mypy` is
-  dropped from the pre-commit config — a proper typing pass needs
-  `django-stubs` and deserves its own scope.
+  and `E203`/`W503`/`E501` ignored for black-compat).
 - One-off format pass across the codebase (trailing whitespace, EOL
   newlines, black reflow on ~4 files, isort re-ordering on ~30 test
   files, 5 legitimate unused imports dropped). Behaviour unchanged.
+- Surgical typing fixes in `cart/` to reach mypy-green:
+  `Item.product` now guards against `ContentType.model_class()`
+  returning `None` (stale-ContentType scenario); `Discount.is_valid_for_cart`
+  and `Discount.calculate_discount` annotate their parameter as the
+  `cart.cart.Cart` facade (the bare model row doesn't have
+  `.summary()`); `cart_admin` uses `@admin.display(description=…)`
+  instead of the legacy `.short_description` attribute pattern;
+  the five optional signal handles are typed `Optional[Signal]`;
+  three `# type: ignore[misc]` suppressions on `product=` kwarg
+  uses (dynamically translated by
+  `ItemManager._inject_content_type`, invisible to django-stubs).
 
 ### Docs
 - README "Iteration and introspection" section adds a callout

--- a/cart/admin.py
+++ b/cart/admin.py
@@ -8,10 +8,9 @@ class ItemInline(admin.TabularInline):
     extra = 0
     readonly_fields = ("content_type", "object_id", "unit_price", "quantity")
 
-    def total_price(self, obj):
+    @admin.display(description="Total")
+    def total_price(self, obj: Item) -> object:
         return obj.total_price
-
-    total_price.short_description = "Total"
 
 
 @admin.register(Cart)
@@ -24,7 +23,6 @@ class CartAdmin(admin.ModelAdmin):
     search_fields = ("=id",)
     inlines = [ItemInline]
 
-    def item_count(self, obj):
+    @admin.display(description="Items")
+    def item_count(self, obj: Cart) -> int:
         return obj.items.count()
-
-    item_count.short_description = "Items"

--- a/cart/cart.py
+++ b/cart/cart.py
@@ -1,20 +1,39 @@
 from decimal import ROUND_HALF_UP, Decimal
+from typing import TYPE_CHECKING, Optional
 
 from django.conf import settings
 from django.db import transaction
 from django.db.models import F, QuerySet, Sum
+from django.dispatch import Signal
 from django.utils import timezone
 
 from . import models
 
+if TYPE_CHECKING:
+    from .shipping import ShippingOption
+
+# ``cart.signals`` is imported defensively: the module is optional (a
+# downstream can remove it) and these five Signal handles are typed as
+# ``Optional[Signal]`` so the ``is not None`` guards at each emit site
+# read cleanly under mypy.
+cart_item_added: Optional[Signal]
+cart_item_removed: Optional[Signal]
+cart_item_updated: Optional[Signal]
+cart_checked_out: Optional[Signal]
+cart_cleared: Optional[Signal]
+
 try:
-    from .signals import (
-        cart_checked_out,
-        cart_cleared,
-        cart_item_added,
-        cart_item_removed,
-        cart_item_updated,
-    )
+    from .signals import cart_checked_out as _cart_checked_out
+    from .signals import cart_cleared as _cart_cleared
+    from .signals import cart_item_added as _cart_item_added
+    from .signals import cart_item_removed as _cart_item_removed
+    from .signals import cart_item_updated as _cart_item_updated
+
+    cart_item_added = _cart_item_added
+    cart_item_removed = _cart_item_removed
+    cart_item_updated = _cart_item_updated
+    cart_checked_out = _cart_checked_out
+    cart_cleared = _cart_cleared
 except ImportError:
     cart_item_added = None
     cart_item_removed = None
@@ -92,14 +111,14 @@ def _parse_serializable_key(key: str, item_data: dict) -> tuple[int, int]:
             "'<content_type_id>:<object_id>' or an integer object_id."
         ) from exc
 
-    content_type_id = item_data.get("content_type_id")
-    if content_type_id is None:
+    content_type_id_raw = item_data.get("content_type_id")
+    if content_type_id_raw is None:
         raise ValueError(
             f"Cannot restore item key={key!r}: payload is missing "
             "'content_type_id'. Pre-v3.0.11 serialised payloads lack "
             "this field and cannot be restored without it."
         )
-    return int(content_type_id), object_id
+    return int(content_type_id_raw), object_id
 
 
 class Cart:
@@ -180,7 +199,12 @@ class Cart:
         return cart
 
     def _get_item(self, product) -> models.Item | None:
-        return models.Item.objects.filter(cart=self.cart, product=product).first()
+        # ``product=`` is rewritten to ``content_type + object_id`` by
+        # ``ItemManager._inject_content_type``. django-stubs doesn't
+        # follow that translation, so the kwarg looks unresolved here.
+        return models.Item.objects.filter(
+            cart=self.cart, product=product  # type: ignore[misc]
+        ).first()
 
     def _invalidate_cache(self) -> None:
         """Invalidate the summary and count cache."""
@@ -297,9 +321,11 @@ class Cart:
                     raise InvalidQuantity(f"Quantity cannot exceed {max_qty}.")
                 item.save(update_fields=["unit_price", "quantity"])
             else:
+                # ``product=`` is rewritten by ItemManager._inject_content_type —
+                # django-stubs can't follow the translation.
                 item = models.Item.objects.create(
                     cart=self.cart,
-                    product=product,
+                    product=product,  # type: ignore[misc]
                     unit_price=unit_price,
                     quantity=int(quantity),
                 )
@@ -641,9 +667,11 @@ class Cart:
                     if max_qty is not None and new_quantity > max_qty:
                         new_quantity = max_qty
 
+                    # ``product=`` goes through ItemManager._inject_content_type —
+                    # django-stubs can't follow the kwarg translation.
                     models.Item.objects.create(
                         cart=self.cart,
-                        product=other_item.product,
+                        product=other_item.product,  # type: ignore[misc]
                         unit_price=other_item.unit_price,
                         quantity=new_quantity,
                     )
@@ -731,9 +759,11 @@ class Cart:
                     item.quantity = quantity
                     item.save(update_fields=["unit_price", "quantity"])
                 else:
+                    # ``product=`` goes through ItemManager._inject_content_type —
+                    # django-stubs can't follow the kwarg translation.
                     item = models.Item.objects.create(
                         cart=self.cart,
-                        product=product,
+                        product=product,  # type: ignore[misc]
                         unit_price=unit_price,
                         quantity=quantity,
                     )
@@ -846,12 +876,13 @@ class Cart:
         calculator = get_shipping_calculator()
         return calculator.calculate(self)
 
-    def shipping_options(self) -> list[dict]:
+    def shipping_options(self) -> "list[ShippingOption]":
         """
         Get available shipping options using the configured ShippingCalculator.
 
         Returns:
-            list[dict]: List of shipping options with id, name, and price.
+            list[ShippingOption]: Each option carries ``id``, ``name``,
+            and ``price`` keys.
 
         Example::
 

--- a/cart/models.py
+++ b/cart/models.py
@@ -13,6 +13,8 @@ from django.utils.translation import gettext_lazy as _
 if TYPE_CHECKING:
     from django.db.models import Model
 
+    from cart.cart import Cart as CartFacade
+
 
 class Cart(models.Model):
     creation_date: models.DateTimeField = models.DateTimeField(
@@ -79,11 +81,11 @@ class Item(models.Model):
         on_delete=models.CASCADE,
         related_name="items",
     )
-    quantity: int = models.PositiveIntegerField(
+    quantity = models.PositiveIntegerField(
         verbose_name=_("quantity"),
         validators=[MinValueValidator(1)],
     )
-    unit_price: Decimal = models.DecimalField(
+    unit_price = models.DecimalField(
         max_digits=18,
         decimal_places=2,
         validators=[MinValueValidator(Decimal("0.00"))],
@@ -91,7 +93,7 @@ class Item(models.Model):
     )
 
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
-    object_id: int = models.PositiveIntegerField()
+    object_id = models.PositiveIntegerField()
 
     objects: ItemManager = ItemManager()
 
@@ -114,9 +116,17 @@ class Item(models.Model):
     @property
     def product(self) -> "Model":
         if not hasattr(self, "_product_cache"):
-            self._product_cache = self.content_type.model_class().objects.get(
-                pk=self.object_id
-            )
+            model = self.content_type.model_class()
+            if model is None:
+                raise LookupError(
+                    f"ContentType {self.content_type_id} does not resolve to "
+                    "an installed model — the product class was likely removed "
+                    "from INSTALLED_APPS without a data migration."
+                )
+            # ``_default_manager`` is the type-stable manager hook on every
+            # Django model (``type[Model]`` under django-stubs). A direct
+            # ``.objects`` lookup would type-check only on concrete subclasses.
+            self._product_cache = model._default_manager.get(pk=self.object_id)
         return self._product_cache
 
     @product.setter
@@ -194,11 +204,13 @@ class Discount(models.Model):
     def __str__(self) -> str:
         return f"{self.code} ({self.get_discount_type_display()}: {self.value})"
 
-    def is_valid_for_cart(self, cart: "Cart") -> tuple[bool, str]:
+    def is_valid_for_cart(self, cart: "CartFacade") -> tuple[bool, str]:
         """Check if the discount is valid for the given cart.
 
         Args:
-            cart: The cart to validate against.
+            cart: The :class:`cart.cart.Cart` facade (not the DB row
+                model). We call ``cart.summary()`` on it — that
+                method lives on the facade.
 
         Returns:
             A tuple of (is_valid, message).
@@ -239,7 +251,10 @@ class Discount(models.Model):
         without compat pain.
         """
         super().clean()
-        errors: dict[str, str] = {}
+        # ``dict[str, Any]`` because ``gettext_lazy`` returns ``_StrPromise``,
+        # not ``str``. ``ValidationError`` accepts either at runtime; the
+        # wider annotation keeps mypy happy without losing the i18n hook.
+        errors: dict[str, Any] = {}
 
         if (
             self.discount_type == DiscountType.PERCENT
@@ -263,7 +278,7 @@ class Discount(models.Model):
         if errors:
             raise ValidationError(errors)
 
-    def calculate_discount(self, cart: "Cart") -> Decimal:
+    def calculate_discount(self, cart: "CartFacade") -> Decimal:
         """Calculate the discount amount for the given cart.
 
         The returned amount is always clamped to the cart's subtotal so
@@ -272,7 +287,8 @@ class Discount(models.Model):
         produce a discount larger than what the cart is worth.
 
         Args:
-            cart: The cart to calculate discount for.
+            cart: The :class:`cart.cart.Cart` facade (provides
+                ``summary()`` — a method absent from the bare model row).
 
         Returns:
             The discount amount as a Decimal, never exceeding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dev = [
     "pytest>=8",
     "pytest-django>=4.8",
     "coverage[toml]>=7",
+    "django-stubs[compatible-mypy]>=5.1",
 ]
 
 # --------------------------------------------------------------------------- #
@@ -82,3 +83,39 @@ fail_under = 90
 
 [tool.coverage.html]
 directory = "htmlcov"
+
+# --------------------------------------------------------------------------- #
+# mypy configuration
+# --------------------------------------------------------------------------- #
+# Type-checking scope:
+# - ``cart/`` is the typed surface (the public API).
+# - ``tests/`` is deliberately excluded — test code is signal-light for
+#   type-check cost (lots of assertions and dynamic fixtures). A follow-up
+#   PR can opt in if the value becomes clear.
+# - Runs on a single cell (Py3.12 × Django 5.1) via pre-commit's
+#   additional_dependencies pin. django-stubs is tied to specific Django
+#   minors and the type-check signal barely varies across the rest of the
+#   test matrix, so one cell is the industry-standard tradeoff.
+# - ``strict = false`` at first — a pragmatic starting point. Individual
+#   tightenings (strict_equality, warn_unused_ignores) ratchet in
+#   follow-ups. ``check_untyped_defs = true`` is the one strict-adjacent
+#   setting that catches real bugs cheaply.
+
+[tool.mypy]
+python_version = "3.12"
+plugins = ["mypy_django_plugin.main"]
+strict = false
+check_untyped_defs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+no_implicit_reexport = false
+exclude = [
+    "^tests/",
+    "^build/",
+    "^dist/",
+    "^.venv/",
+    "^.*/migrations/.*",
+]
+
+[tool.django-stubs]
+django_settings_module = "tests.settings"


### PR DESCRIPTION
## Summary

PR #82 dropped mypy from pre-commit because the 18-month-stale `1.8.0` pin segfaulted the installer on Py3.12. Refreshing the version alone wouldn't have produced useful output either — Django's ORM doesn't type-check meaningfully without `django-stubs`. This PR does the real work per your approvals:

- ✅ Py3.12 × Django 5.1 single cell
- ✅ `strict = false` (with `check_untyped_defs = true`)
- ✅ `django-stubs[compatible-mypy]` pinned (pins mypy for us)

## Config

| File | Change |
|------|--------|
| `pyproject.toml` | `dev` deps add `django-stubs[compatible-mypy]>=5.1`. New `[tool.mypy]` block (plugins, strict=false, check_untyped_defs=true, tests/ + migrations excluded). New `[tool.django-stubs]` pointing at `tests.settings`. |
| `.pre-commit-config.yaml` | New `mirrors-mypy` hook scoped to `files: ^cart/`, with `additional_dependencies` pinning `django-stubs[compatible-mypy]>=5.1` and `Django>=5.1,<5.2`. |

The single-cell choice is deliberate: `django-stubs` is Django-minor-coupled and the type-check signal barely varies across the rest of the test matrix. Running on every cell would duplicate the same signal at 19× the cost.

## First pass surfaced 25 errors — here's how they went down

| # | Category | Fix |
|---|----------|-----|
| 6 | Field type annotations like `quantity: int = models.PositiveIntegerField(...)` | Dropped — django-stubs infers correctly from the field. |
| 2 | `content_type.model_class().objects.get(...)` returns `Optional[type[Model]]` | Null-guard + switched to `_default_manager` (type-stable). |
| 2 | `Discount.is_valid_for_cart(cart: "Cart")` — the facade is what's passed, not the model row | `TYPE_CHECKING` import of `CartFacade`. |
| 2 | `gettext_lazy`'s `_StrPromise` assigned into `dict[str, str]` | Widened to `dict[str, Any]` (ValidationError accepts either at runtime). |
| 2 | `admin` methods with `.short_description = "..."` attribute | Replaced with `@admin.display(description="...")`. |
| 5 | `Signal | None` fallback after `try/except ImportError` | Explicit `Optional[Signal]` annotations. |
| 1 | `cart_id = self._session.get_or_create_cart_id()` (Any|None) assigned to `int` | Local var rename for clean narrowing. |
| 4 | `product=` kwarg + `.product` access (dynamic via `ItemManager._inject_content_type`) | Three narrowly-scoped `# type: ignore[misc]` with one-line explanations. |
| 1 | `shipping_options() -> list[dict]` — calculator returns `list[ShippingOption]` TypedDict | Tightened return annotation. |

`uv run mypy cart/` → **zero errors** (15 source files checked).

## Why bring mypy back at all

Covered in detail in the message that prompted this PR. Short version: the `Cart` facade is our public API; IDE completions and downstream mypy runs on consuming projects depend on our annotations being truthful. Before this PR, annotations were aspirational — no verification. This PR turns them into load-bearing type contracts, which is exactly the point of shipping a typed library.

## Test plan

- [x] `uv run mypy cart/` → **Success: no issues found in 15 source files**.
- [x] `uv run pytest` → **334 passed**, unchanged.
- [x] `uv run pytest --ds=tests.settings_custom_user tests/test_cart_custom_user.py` → **4 passed**, unchanged.
- [x] `uv tool run --from pre-commit@latest pre-commit run --all-files` → all 9 hooks passing (including mypy).
- [x] CI `Lint` job already runs pre-commit, so mypy gets picked up automatically.

## Notes for reviewer

- No version bump. Stays in `[Unreleased]`.
- No behavioural changes; all fixes are annotations + documented suppressions. Two minor runtime-visible changes: `Item.product` now raises `LookupError` on stale ContentType (was silent `AttributeError` via `None.objects`), and admin column helpers use `@admin.display` — identical UX, different code path.
- Next candidates after this: the v3.1.0 minor release (breaking: `can_checkout()` enforcement + `CARTS_SESSION_ADAPTER_CLASS` rename), or more targeted mypy tightening per-module (e.g. `strict = true` for `cart/cart.py` once consumers have caught up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)