### PR TITLE
feat(v3.1.0): enforce can_checkout() in checkout(); rename session setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+## [3.1.0] — 2026-04-21
+
+### ⚠️ Breaking changes
+
+- **`Cart.checkout()` now enforces `can_checkout()` before mutating.**
+  Pre-v3.1 the method happily marked an empty cart (or a cart below
+  `settings.CART_MIN_ORDER_AMOUNT`) as checked-out — a documented
+  footgun. It now raises `CartException("Cart is empty.")` on empty
+  carts and `MinimumOrderNotMet(...)` on below-minimum carts
+  (finally using the long-defined exception class). Callers that
+  relied on lax behaviour must either call `can_checkout()` themselves
+  upstream or catch the new exceptions.
+- **`CARTS_SESSION_ADAPTER_CLASS` renamed to `CART_SESSION_ADAPTER`**
+  (plural → singular, matching `CART_TAX_CALCULATOR` /
+  `CART_SHIPPING_CALCULATOR` / `CART_INVENTORY_CHECKER`). The legacy
+  plural setting is still honoured but emits a `DeprecationWarning`
+  and will be removed in v4.0. When both are set, the new singular
+  setting wins.
+
 ### Added
 - `Cart.items_with_products()` — batch-prefetching iteration path.
   Loads items with `select_related('content_type')`, groups by

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ graph TB
 
     View["Django view<br>or DRF endpoint"]
     Cart["Cart facade<br>cart.cart.Cart"]:::facade
-    Session["Session Adapter<br>CARTS_SESSION_ADAPTER_CLASS"]:::store
+    Session["Session Adapter<br>CART_SESSION_ADAPTER"]:::store
     DB[("Cart, Item, Discount<br>database rows")]:::store
 
     Tax["Tax Calculator<br>CART_TAX_CALCULATOR"]:::plug
@@ -372,12 +372,16 @@ restored = Cart.from_serializable(new_request, payload)
 ### Checkout
 
 ```python
-can, message = cart.can_checkout()
-if not can:
-    return render(request, "cart/detail.html", {"cart": cart, "error": message})
+from cart.cart import CartException, InvalidDiscountError, MinimumOrderNotMet
 
 try:
     cart.checkout()
+except CartException as e:
+    # Empty cart.
+    return render(request, "cart/detail.html", {"cart": cart, "error": str(e)})
+except MinimumOrderNotMet as e:
+    # Subtotal below CART_MIN_ORDER_AMOUNT.
+    return render(request, "cart/detail.html", {"cart": cart, "error": str(e)})
 except InvalidDiscountError as e:
     # A discount was applied earlier but is no longer valid
     # (expired, deactivated, or max_uses reached between apply
@@ -388,6 +392,11 @@ except InvalidDiscountError as e:
 
 `checkout()` is:
 
+- **Validated.** Enforces `can_checkout()` before touching the DB
+  (v3.1.0). An empty cart raises `CartException`; a cart below
+  `settings.CART_MIN_ORDER_AMOUNT` raises `MinimumOrderNotMet`.
+  Pre-v3.1 both were silent no-ops — downstream code had to call
+  `can_checkout()` explicitly.
 - **Atomic.** Marks the cart checked-out and (if a discount is
   applied) increments `Discount.current_uses` in the same
   transaction.
@@ -422,7 +431,7 @@ All cart exceptions subclass `cart.cart.CartException`.
 | `PriceMismatchError` | `validate_price=True` and `unit_price != product.price` |
 | `InsufficientStock` | `check_inventory=True` and the configured `InventoryChecker.check()` returns `False` |
 | `InvalidDiscountError` | bad code, already-applied discount, failed validity check, revalidation failure at checkout |
-| `MinimumOrderNotMet` | defined but not raised by the library itself; surfaced via `can_checkout()` as `(False, message)` |
+| `MinimumOrderNotMet` | raised by `checkout()` when `cart.summary() < settings.CART_MIN_ORDER_AMOUNT` (v3.1.0+) |
 
 ---
 
@@ -674,16 +683,23 @@ flowchart LR
 
 ```python
 # settings.py — dotted string
-CARTS_SESSION_ADAPTER_CLASS = "cart.session.CookieSessionAdapter"
+CART_SESSION_ADAPTER = "cart.session.CookieSessionAdapter"
 
 # or — class object
 from cart.session import CookieSessionAdapter
-CARTS_SESSION_ADAPTER_CLASS = CookieSessionAdapter
+CART_SESSION_ADAPTER = CookieSessionAdapter
 ```
 
 Both forms work. A typo in the dotted path raises `ImportError`
 loudly — this is the one subsystem factory that does **not** fall
 back silently.
+
+> [!note] Migrating from `CARTS_SESSION_ADAPTER_CLASS`
+> v3.1.0 renamed this setting from the plural
+> `CARTS_SESSION_ADAPTER_CLASS` to the singular `CART_SESSION_ADAPTER`
+> for symmetry with the other `CART_*` settings. The legacy name is
+> still honoured but emits a `DeprecationWarning` and will be removed
+> in v4.0. If both are set, the new singular setting wins.
 
 > [!important]
 > `CookieSessionAdapter` (and any custom cookie-backed adapter) also
@@ -741,7 +757,7 @@ class RedisSessionAdapter(CartSessionAdapter):
 
 ```python
 # settings.py
-CARTS_SESSION_ADAPTER_CLASS = "myapp.session.RedisSessionAdapter"
+CART_SESSION_ADAPTER = "myapp.session.RedisSessionAdapter"
 ```
 
 See [`docs/AGENTS.md`](docs/AGENTS.md) for a prompt-ready version
@@ -875,7 +891,7 @@ or `None`.
 | `CART_TAX_CALCULATOR` | dotted path or class | `DefaultTaxCalculator` → `Decimal("0.00")` | Tax calculator class. See [Tax](#tax). |
 | `CART_SHIPPING_CALCULATOR` | dotted path or class | `DefaultShippingCalculator` → `Decimal("0.00")`, one "free" option | Shipping calculator class. See [Shipping](#shipping). |
 | `CART_INVENTORY_CHECKER` | dotted path or class | `DefaultInventoryChecker` → always `True` | Inventory checker class. See [Inventory](#inventory). |
-| `CARTS_SESSION_ADAPTER_CLASS` | dotted path or class | `DjangoSessionAdapter` | Where the integer cart id is stored. See [Session Storage](#session-storage). |
+| `CART_SESSION_ADAPTER` | dotted path or class | `DjangoSessionAdapter` | Where the integer cart id is stored. See [Session Storage](#session-storage). The legacy `CARTS_SESSION_ADAPTER_CLASS` is still honoured with a `DeprecationWarning` through v3.x. |
 | `CART_MAX_QUANTITY_PER_ITEM` | int or `None` | `None` (unlimited) | Cap on `item.quantity`. Exceeding raises `InvalidQuantity`. |
 | `CART_MIN_ORDER_AMOUNT` | `Decimal` or `None` | `None` (no minimum) | Minimum `cart.summary()` required for `can_checkout()` to return `True`. |
 | `CART_DETAIL_URL_NAME` | str or `None` | `None` | URL name passed to `reverse()` by the `{% cart_link %}` template tag. Falls back to a static `/cart/` when unset or unresolvable. See [Template Tags](#template-tags). |

--- a/cart/cart.py
+++ b/cart/cart.py
@@ -153,13 +153,22 @@ class Cart:
 
     @staticmethod
     def _build_session_adapter(request):
-        """Construct the session adapter named by ``CARTS_SESSION_ADAPTER_CLASS``.
+        """Construct the session adapter named by ``CART_SESSION_ADAPTER``.
 
         Accepts either a dotted import path or a class object. If the
         setting is unset, falls back to :class:`DjangoSessionAdapter`.
         A bad dotted path raises ``ImportError`` — session storage is
         too critical to silently fall back to the default (unlike the
         tax / shipping / inventory factories).
+
+        v3.1.0 renamed this setting from the plural
+        ``CARTS_SESSION_ADAPTER_CLASS`` to the singular
+        ``CART_SESSION_ADAPTER`` — the former was asymmetric with
+        ``CART_TAX_CALCULATOR`` / ``CART_SHIPPING_CALCULATOR`` /
+        ``CART_INVENTORY_CHECKER``. The legacy plural setting is still
+        honoured for back-compat but emits a :class:`DeprecationWarning`
+        pointing at the new name. If both are set, the new singular
+        setting wins and the legacy value is ignored.
 
         The adapter is cached on ``request._cart_session`` so that:
         (a) multiple ``Cart(request)`` constructions within one request
@@ -175,7 +184,22 @@ class Cart:
 
         from .session import DjangoSessionAdapter
 
-        adapter = getattr(settings, "CARTS_SESSION_ADAPTER_CLASS", None)
+        adapter = getattr(settings, "CART_SESSION_ADAPTER", None)
+        if adapter is None:
+            legacy = getattr(settings, "CARTS_SESSION_ADAPTER_CLASS", None)
+            if legacy is not None:
+                import warnings
+
+                warnings.warn(
+                    "`CARTS_SESSION_ADAPTER_CLASS` is deprecated since v3.1.0 "
+                    "and will be removed in v4.0.0. Rename it to "
+                    "`CART_SESSION_ADAPTER` (singular, matching the other "
+                    "`CART_*` settings).",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+                adapter = legacy
+
         if adapter is None:
             instance = DjangoSessionAdapter(request)
         else:
@@ -454,6 +478,14 @@ class Cart:
     def checkout(self) -> None:
         """Mark the cart as checked out.
 
+        v3.1.0 enforces :meth:`can_checkout` at the start — an empty
+        cart raises :class:`CartException`, and a cart below
+        ``settings.CART_MIN_ORDER_AMOUNT`` raises
+        :class:`MinimumOrderNotMet`. Callers that used to rely on the
+        lax pre-3.1 behaviour (checkout succeeded on any cart state)
+        need to either call :meth:`can_checkout` themselves before
+        invoking checkout, or catch the new exceptions.
+
         If a discount is applied, revalidates it under a row-level lock
         and atomically increments its ``current_uses`` counter in the
         same transaction. If the discount became invalid between
@@ -473,11 +505,24 @@ class Cart:
         ``self.cart.checked_out`` handles the common case where the
         same facade is called twice.
 
+        :raises CartException: if the cart is empty.
+        :raises MinimumOrderNotMet: if the cart total is below
+            ``settings.CART_MIN_ORDER_AMOUNT``.
         :raises InvalidDiscountError: if an applied discount fails
             revalidation at checkout time.
         """
         if self.cart.checked_out:
             return
+
+        if self.is_empty():
+            raise CartException("Cart is empty.")
+
+        min_amount = getattr(settings, "CART_MIN_ORDER_AMOUNT", None)
+        if min_amount is not None and self.summary() < min_amount:
+            raise MinimumOrderNotMet(
+                f"Cart total {self.summary()} is below the minimum "
+                f"order amount of {min_amount}."
+            )
 
         with transaction.atomic():
             locked_cart = models.Cart.objects.select_for_update().get(pk=self.cart.pk)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-cart"
-version = "3.0.14"
+version = "3.1.0"
 authors = [
   { name="Bruno Mentges de Carvalho", email="bruno@mentgesinformatica.com.br" },
 ]

--- a/tests/test_cart_checkout.py
+++ b/tests/test_cart_checkout.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 
 import pytest
 
-from cart.cart import Cart
+from cart.cart import Cart, CartException, MinimumOrderNotMet
 
 pytestmark = pytest.mark.django_db
 
@@ -73,14 +73,35 @@ def test_checkout_marks_the_cart_checked_out(cart, product):
     assert cart.cart.checked_out is True
 
 
-def test_checkout_is_allowed_on_an_empty_cart_by_design(cart):
-    """Until P1-2 lands in 3.1.0, Cart.checkout() is lax by design —
-    it does not enforce can_checkout(). This test locks in the current
-    contract so P1-2's change surfaces clearly on diff."""
-    cart.checkout()
+def test_checkout_rejects_empty_cart_with_cart_exception(cart):
+    """v3.1.0 BREAKING: ``Cart.checkout()`` now enforces
+    ``can_checkout()`` before mutating. Empty-cart checkouts raise
+    ``CartException`` instead of silently marking an empty cart as
+    checked out — which was a documented footgun before (every
+    abandoned cart could be "checked out" and poison analytics)."""
+    with pytest.raises(CartException, match="empty"):
+        cart.checkout()
 
     cart.cart.refresh_from_db()
-    assert cart.cart.checked_out is True
+    assert cart.cart.checked_out is False
+
+
+def test_checkout_rejects_cart_below_min_order_amount_with_minimum_order_not_met(
+    cart, product, settings
+):
+    """v3.1.0 BREAKING: sub-minimum carts now raise
+    ``MinimumOrderNotMet`` at checkout time. The exception class has
+    existed since v3.0.0 but was never raised by the library itself —
+    callers only saw the message via ``can_checkout()``'s
+    ``(False, message)`` tuple and had to implement their own check."""
+    settings.CART_MIN_ORDER_AMOUNT = Decimal("500.00")
+    cart.add(product, unit_price=Decimal("100.00"), quantity=2)
+
+    with pytest.raises(MinimumOrderNotMet, match="500.00"):
+        cart.checkout()
+
+    cart.cart.refresh_from_db()
+    assert cart.cart.checked_out is False
 
 
 # --------------------------------------------------------------------------- #
@@ -88,7 +109,8 @@ def test_checkout_is_allowed_on_an_empty_cart_by_design(cart):
 # --------------------------------------------------------------------------- #
 
 
-def test_a_fresh_request_after_checkout_yields_a_new_cart(cart, rf_request):
+def test_a_fresh_request_after_checkout_yields_a_new_cart(cart, product, rf_request):
+    cart.add(product, Decimal("1.00"))
     cart.checkout()
 
     fresh = Cart(rf_request)

--- a/tests/test_cart_init.py
+++ b/tests/test_cart_init.py
@@ -96,12 +96,13 @@ def test_shared_session_yields_same_cart_across_requests():
     assert c1.cart.pk == c2.cart.pk
 
 
-def test_carts_session_adapter_class_setting_is_honoured(settings, rf_request):
-    """Setting the adapter class should cause Cart to route session ops
-    through it, leaving request.session untouched."""
-    settings.CARTS_SESSION_ADAPTER_CLASS = (
-        "tests.test_cart_init._RecordingSessionAdapter"
-    )
+def test_cart_session_adapter_setting_routes_session_ops_through_the_adapter(
+    settings, rf_request
+):
+    """Setting ``CART_SESSION_ADAPTER`` should cause Cart to route
+    session ops through the configured adapter, leaving
+    ``request.session`` untouched."""
+    settings.CART_SESSION_ADAPTER = "tests.test_cart_init._RecordingSessionAdapter"
 
     Cart(rf_request)
 
@@ -111,9 +112,7 @@ def test_carts_session_adapter_class_setting_is_honoured(settings, rf_request):
 def test_adapter_receives_the_new_cart_id_on_creation(settings, rf_request):
     """The adapter's set_cart_id must be called with the freshly-created
     cart's pk when the session had no prior cart."""
-    settings.CARTS_SESSION_ADAPTER_CLASS = (
-        "tests.test_cart_init._RecordingSessionAdapter"
-    )
+    settings.CART_SESSION_ADAPTER = "tests.test_cart_init._RecordingSessionAdapter"
     _RecordingSessionAdapter.calls.clear()
 
     cart = Cart(rf_request)
@@ -126,7 +125,7 @@ def test_setting_accepts_a_class_object_not_just_a_dotted_string(settings, rf_re
     """The README advertises both
     ``CARTS_SESSION_ADAPTER_CLASS = MyAdapter`` and
     ``= "dotted.path.MyAdapter"`` — both must work."""
-    settings.CARTS_SESSION_ADAPTER_CLASS = _RecordingSessionAdapter
+    settings.CART_SESSION_ADAPTER = _RecordingSessionAdapter
     _RecordingSessionAdapter.calls.clear()
 
     Cart(rf_request)
@@ -139,7 +138,66 @@ def test_bad_dotted_path_raises_loudly_no_silent_fallback(settings, rf_request):
     """Session storage is too critical to silently fall back to the
     default on a typo — unlike the tax / shipping / inventory
     factories. A bad dotted path must raise."""
-    settings.CARTS_SESSION_ADAPTER_CLASS = "nonexistent.module.FakeAdapter"
+    settings.CART_SESSION_ADAPTER = "nonexistent.module.FakeAdapter"
 
     with pytest.raises(ImportError):
         Cart(rf_request)
+
+
+# --------------------------------------------------------------------------- #
+# v3.1.0: CART_SESSION_ADAPTER is the new canonical (singular) name;
+# CARTS_SESSION_ADAPTER_CLASS is still honoured with a DeprecationWarning.
+# --------------------------------------------------------------------------- #
+
+
+def test_CART_SESSION_ADAPTER_singular_setting_is_honoured(settings, rf_request):
+    """The new canonical setting name — singular ``CART_SESSION_ADAPTER``
+    — matches the ``CART_TAX_CALCULATOR`` / ``CART_SHIPPING_CALCULATOR``
+    / ``CART_INVENTORY_CHECKER`` pattern. No warning fires when it's
+    used."""
+    import warnings
+
+    settings.CART_SESSION_ADAPTER = "tests.test_cart_init._RecordingSessionAdapter"
+    _RecordingSessionAdapter.calls.clear()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        Cart(rf_request)
+
+    assert ("get_or_create_cart_id",) in _RecordingSessionAdapter.calls
+
+
+def test_legacy_CARTS_SESSION_ADAPTER_CLASS_still_works_with_deprecation_warning(
+    settings, rf_request
+):
+    """Back-compat — the pre-v3.1.0 plural setting still wires the
+    adapter through, but emits a DeprecationWarning naming the new
+    singular setting so downstream users have a clean migration path."""
+    settings.CART_SESSION_ADAPTER = None
+    settings.CARTS_SESSION_ADAPTER_CLASS = (
+        "tests.test_cart_init._RecordingSessionAdapter"
+    )
+    _RecordingSessionAdapter.calls.clear()
+
+    with pytest.warns(DeprecationWarning, match="CART_SESSION_ADAPTER"):
+        Cart(rf_request)
+
+    assert ("get_or_create_cart_id",) in _RecordingSessionAdapter.calls
+
+
+def test_new_setting_takes_precedence_over_legacy_when_both_set(settings, rf_request):
+    """If someone has both defined during a migration window, the new
+    singular setting wins and no warning fires — the legacy value is
+    ignored."""
+    import warnings
+
+    settings.CART_SESSION_ADAPTER = "tests.test_cart_init._RecordingSessionAdapter"
+    settings.CARTS_SESSION_ADAPTER_CLASS = "nonexistent.module.WouldCrash"
+    _RecordingSessionAdapter.calls.clear()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        Cart(rf_request)
+
+    # No ImportError — new setting was read, legacy ignored.
+    assert ("get_or_create_cart_id",) in _RecordingSessionAdapter.calls

--- a/tests/test_cookie_session_middleware.py
+++ b/tests/test_cookie_session_middleware.py
@@ -2,7 +2,7 @@
 integration via ``CartCookieMiddleware``.
 
 P0-A from docs/ANALYSIS.md: before the middleware existed, setting
-``CARTS_SESSION_ADAPTER_CLASS = "cart.session.CookieSessionAdapter"``
+``CART_SESSION_ADAPTER = "cart.session.CookieSessionAdapter"``
 produced silent data loss — the adapter wrote cookies only to an
 in-memory dict, so the browser never received ``Set-Cookie: CART-ID=…``
 and every request created a fresh ``cart.models.Cart`` row.
@@ -33,7 +33,7 @@ def cookie_adapter_settings(settings):
     ``settings`` fixture watches the setting, not the list object, so
     in-place ``.append()`` wouldn't be restored at teardown.
     """
-    settings.CARTS_SESSION_ADAPTER_CLASS = "cart.session.CookieSessionAdapter"
+    settings.CART_SESSION_ADAPTER = "cart.session.CookieSessionAdapter"
     settings.MIDDLEWARE = list(settings.MIDDLEWARE) + [
         "cart.middleware.CartCookieMiddleware",
     ]

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -146,7 +146,8 @@ def test_cart_item_updated_carries_deleted_flag_on_zero_quantity(
 # --------------------------------------------------------------------------- #
 
 
-def test_cart_checked_out_fires_on_checkout(cart, signal_sink):
+def test_cart_checked_out_fires_on_checkout(cart, product, signal_sink):
+    cart.add(product, unit_price=Decimal("1.00"))
     cart.checkout()
 
     assert len(signal_sink["checked_out"]) == 1


### PR DESCRIPTION
## Summary

Cuts **v3.1.0** with the two breaking-change items from [`docs/ANALYSIS.md`](docs/ANALYSIS.md) §14's v3.1.0 slot. Pure release PR — version bump + CHANGELOG + README + the actual breaking changes in one reviewable unit.

## ⚠️ Breaking changes

### 1. `Cart.checkout()` enforces `can_checkout()` before mutating

Pre-v3.1 the method silently marked any cart — including empty or below-minimum — as checked out. Now it raises:

| Condition | Exception |
|-----------|-----------|
| `cart.is_empty()` | `CartException("Cart is empty.")` |
| `cart.summary() < settings.CART_MIN_ORDER_AMOUNT` | `MinimumOrderNotMet(...)` — finally using the long-defined class |

Callers that relied on lax behaviour need to either call `can_checkout()` upstream or catch the new exceptions.

### 2. `CARTS_SESSION_ADAPTER_CLASS` → `CART_SESSION_ADAPTER`

Plural name was asymmetric with `CART_TAX_CALCULATOR` / `CART_SHIPPING_CALCULATOR` / `CART_INVENTORY_CHECKER`. Singular form is canonical. Back-compat:

- Old name still honoured, emits `DeprecationWarning` — removal slated for v4.0.
- When both are set, the new singular wins (legacy is ignored, no warning).

## TDD

- `test_checkout_rejects_empty_cart_with_cart_exception` — flips the old "empty-cart-by-design" locked test.
- `test_checkout_rejects_cart_below_min_order_amount_with_minimum_order_not_met` — master silently succeeds; branch raises.
- Three setting-rename tests: canonical name honoured, legacy still works with `DeprecationWarning`, new takes precedence when both set.

## Test plan

- [x] `uv run pytest` → **338 passed** (335 → +3 for P1-3, net after the two flipped checkout tests).
- [x] `uv run pytest --ds=tests.settings_custom_user tests/test_cart_custom_user.py` → **4 passed**.
- [x] `pre-commit run --all-files` → all 9 hooks clean (including mypy).
- [x] Two existing tests that checked out empty carts updated to add a product first.
- [x] Four existing tests that used `CARTS_SESSION_ADAPTER_CLASS` migrated to the new name — the dedicated deprecation test now owns legacy-path coverage.

## Migration guide for downstream

```python
# Before v3.1.0
can, msg = cart.can_checkout()
if can:
    cart.checkout()  # would've silently succeeded even when not can

# After v3.1.0 — either call can_checkout() yourself...
can, msg = cart.can_checkout()
if can:
    cart.checkout()

# ...or let checkout() raise
try:
    cart.checkout()
except CartException as e:
    # empty cart
    ...
except MinimumOrderNotMet as e:
    # below CART_MIN_ORDER_AMOUNT
    ...
```

```python
# settings.py — before v3.1.0
CARTS_SESSION_ADAPTER_CLASS = "cart.session.CookieSessionAdapter"

# settings.py — after v3.1.0 (old still works with DeprecationWarning through v3.x)
CART_SESSION_ADAPTER = "cart.session.CookieSessionAdapter"
```

## After merge

Tag `v3.1.0` on the merge commit — CI publish job uploads to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)