### PR TITLE
perf: cache tax/shipping/discount_amount/total on the Cart instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Changed
+- `Cart.tax()`, `Cart.shipping()`, `Cart.discount_amount()`, and
+  `Cart.total()` now cache their results on the `Cart` instance
+  (ANALYSIS §8.2). `_invalidate_cache()` — already called from every
+  mutation — resets them alongside `summary()` and `count()`. A
+  template that renders subtotal + tax + shipping + total + discount
+  alongside each other used to invoke each configured calculator up
+  to 4× per render (once for the standalone field, once inside
+  `total()`); it now invokes each exactly once per `Cart` instance.
+  Tax and shipping calculators in the wild frequently hit external
+  APIs (Stripe Tax, Avalara, TaxJar), so this translates directly to
+  fewer round-trips per request.
 
 ## [3.1.0] — 2026-04-21
 

--- a/README.md
+++ b/README.md
@@ -304,10 +304,11 @@ cart.discount_amount()    # Decimal — 0.00 if no discount applied
 cart.total()              # Decimal — summary − discount + tax + shipping
 ```
 
-`summary()` and `count()` are cached on the `Cart` instance and
-invalidated on every mutation. `tax()` / `shipping()` call out to
-the configured calculators on each call — if they are expensive,
-memoise on the calculator side.
+All six methods above — `summary()`, `count()`, `tax()`, `shipping()`,
+`discount_amount()`, `total()` — are cached on the `Cart` instance
+and invalidated on every mutation. A template that renders subtotal
++ tax + shipping + discount + total calls each configured calculator
+exactly once per request, not once per displayed field.
 
 ### User binding and merging
 

--- a/cart/cart.py
+++ b/cart/cart.py
@@ -821,12 +821,21 @@ class Cart:
         """
         Return the discount amount for the applied discount.
 
+        Result is cached on the Cart instance and invalidated by the next
+        mutation. Useful when :meth:`total` and a "you saved $X" display
+        both read it in the same render.
+
         Returns:
             Decimal: The discount amount, or Decimal("0.00") if no discount applied.
         """
+        if "discount_amount" in self._cache:
+            return self._cache["discount_amount"]
         if self.cart.discount is None:
-            return Decimal("0.00")
-        return self.cart.discount.calculate_discount(self)
+            amount = Decimal("0.00")
+        else:
+            amount = self.cart.discount.calculate_discount(self)
+        self._cache["discount_amount"] = amount
+        return amount
 
     def discount_code(self) -> str | None:
         """
@@ -893,6 +902,11 @@ class Cart:
         """
         Calculate tax for the cart using the configured TaxCalculator.
 
+        Result is cached on the Cart instance and invalidated by the
+        next mutation. Tax calculators can hit external APIs (Stripe
+        Tax, Avalara, TaxJar) — a template that renders tax alongside
+        total would otherwise pay for two remote calls.
+
         Returns:
             Decimal: The calculated tax amount.
 
@@ -900,14 +914,21 @@ class Cart:
 
             tax_amount = cart.tax()
         """
+        if "tax" in self._cache:
+            return self._cache["tax"]
         from .tax import get_tax_calculator
 
         calculator = get_tax_calculator()
-        return calculator.calculate(self)
+        amount = calculator.calculate(self)
+        self._cache["tax"] = amount
+        return amount
 
     def shipping(self) -> Decimal:
         """
         Calculate shipping cost for the cart using the configured ShippingCalculator.
+
+        Result is cached on the Cart instance and invalidated by the
+        next mutation. See :meth:`tax` for the motivating use case.
 
         Returns:
             Decimal: The calculated shipping cost.
@@ -916,10 +937,14 @@ class Cart:
 
             shipping_cost = cart.shipping()
         """
+        if "shipping" in self._cache:
+            return self._cache["shipping"]
         from .shipping import get_shipping_calculator
 
         calculator = get_shipping_calculator()
-        return calculator.calculate(self)
+        amount = calculator.calculate(self)
+        self._cache["shipping"] = amount
+        return amount
 
     def shipping_options(self) -> "list[ShippingOption]":
         """
@@ -972,13 +997,18 @@ class Cart:
         """
         Calculate the total cart value including discounts, tax, and shipping.
 
-        The returned value is always quantized to two decimal places
-        with ``ROUND_HALF_UP``. Aggregating ``subtotal``, ``discount``,
-        ``tax``, and ``shipping`` can produce long-tail digits when any
-        of them is a computed rate (e.g. a compound tax), and leaking
-        that noise into display or downstream storage surprises
-        consumers who assume 2dp. Rounding at the boundary keeps every
-        caller on the same footing.
+        Result is cached on the Cart instance and invalidated by the
+        next mutation. The four inputs (:meth:`summary`,
+        :meth:`discount_amount`, :meth:`tax`, :meth:`shipping`) are
+        each cached too, so the first call to ``total()`` runs each
+        calculator exactly once and subsequent calls return the cached
+        Decimal without touching Python's arithmetic at all.
+
+        Quantized to two decimal places with ``ROUND_HALF_UP``.
+        Aggregating ``subtotal − discount + tax + shipping`` can
+        produce long-tail digits when any of them is a computed rate
+        (e.g. a compound tax), and leaking that noise into display or
+        downstream storage surprises consumers who assume 2dp.
 
         Returns:
             Decimal: The final total amount, quantized to 2dp, never
@@ -988,6 +1018,8 @@ class Cart:
 
             total = cart.total()  # summary - discount + tax + shipping
         """
+        if "total" in self._cache:
+            return self._cache["total"]
         subtotal = self.summary()
         discount = self.discount_amount()
         tax = self.tax()
@@ -995,4 +1027,6 @@ class Cart:
 
         total = subtotal - discount + tax + shipping
         total = max(total, Decimal("0.00"))
-        return total.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        total = total.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        self._cache["total"] = total
+        return total

--- a/tests/test_cart_caching.py
+++ b/tests/test_cart_caching.py
@@ -102,3 +102,140 @@ def test_cache_holds_up_under_many_summary_calls_on_large_cart(
     with django_assert_max_num_queries(1):
         for _ in range(10):
             cart.summary()
+
+
+# --------------------------------------------------------------------------- #
+# Calculator-value caching — tax / shipping / discount_amount / total
+#
+# ANALYSIS §8.2: a template that displays subtotal, tax, shipping, and
+# total invokes three calculators (and the discount computation) per
+# render of total() plus one each for the individual tax()/shipping()
+# calls. Caching them on ``_cache`` means each calculator runs exactly
+# once per Cart instance, with ``_invalidate_cache()`` (called from
+# every mutation) resetting the lot.
+# --------------------------------------------------------------------------- #
+
+from cart.shipping import ShippingCalculator  # noqa: E402
+from cart.tax import TaxCalculator  # noqa: E402
+
+
+class _CountingTaxCalculator(TaxCalculator):
+    """Flat-rate tax calculator that counts how often ``calculate()`` runs."""
+
+    call_count = 0
+
+    def calculate(self, cart):
+        _CountingTaxCalculator.call_count += 1
+        return cart.summary() * Decimal("0.10")
+
+
+class _CountingShippingCalculator(ShippingCalculator):
+    """Flat-rate shipping calculator that counts how often ``calculate()`` runs."""
+
+    call_count = 0
+
+    def calculate(self, cart):
+        _CountingShippingCalculator.call_count += 1
+        return Decimal("9.99")
+
+    def get_options(self, cart):
+        return [{"id": "flat", "name": "Flat", "price": Decimal("9.99")}]
+
+
+def test_tax_is_cached_across_calls(cart, product, settings):
+    """Repeated ``cart.tax()`` calls must hit the cache after the first.
+    Tax calculators can be expensive in the wild (external APIs — Stripe
+    Tax, Avalara, TaxJar) so recomputing per call is a real cost."""
+    settings.CART_TAX_CALCULATOR = "tests.test_cart_caching._CountingTaxCalculator"
+    _CountingTaxCalculator.call_count = 0
+    cart.add(product, Decimal("100.00"), quantity=1)
+
+    for _ in range(5):
+        cart.tax()
+
+    assert _CountingTaxCalculator.call_count == 1
+
+
+def test_shipping_is_cached_across_calls(cart, product, settings):
+    settings.CART_SHIPPING_CALCULATOR = (
+        "tests.test_cart_caching._CountingShippingCalculator"
+    )
+    _CountingShippingCalculator.call_count = 0
+    cart.add(product, Decimal("50.00"), quantity=1)
+
+    for _ in range(5):
+        cart.shipping()
+
+    assert _CountingShippingCalculator.call_count == 1
+
+
+def test_total_does_not_reinvoke_calculators_on_repeat_calls(cart, product, settings):
+    """``cart.total()`` combines summary / discount / tax / shipping.
+    Callers that render subtotal + tax + shipping + total shouldn't
+    pay for four calculator runs per field."""
+    settings.CART_TAX_CALCULATOR = "tests.test_cart_caching._CountingTaxCalculator"
+    settings.CART_SHIPPING_CALCULATOR = (
+        "tests.test_cart_caching._CountingShippingCalculator"
+    )
+    _CountingTaxCalculator.call_count = 0
+    _CountingShippingCalculator.call_count = 0
+    cart.add(product, Decimal("100.00"), quantity=2)
+
+    for _ in range(4):
+        cart.total()
+
+    assert _CountingTaxCalculator.call_count == 1
+    assert _CountingShippingCalculator.call_count == 1
+
+
+def test_add_invalidates_tax_and_shipping_caches(cart, product, settings):
+    """A mutation must reset the tax / shipping cache — otherwise the
+    template's subtotal updates but the tax line stays stale."""
+    settings.CART_TAX_CALCULATOR = "tests.test_cart_caching._CountingTaxCalculator"
+    settings.CART_SHIPPING_CALCULATOR = (
+        "tests.test_cart_caching._CountingShippingCalculator"
+    )
+    _CountingTaxCalculator.call_count = 0
+    _CountingShippingCalculator.call_count = 0
+    cart.add(product, Decimal("10.00"), quantity=1)
+    cart.tax()
+    cart.shipping()
+
+    cart.add(product, Decimal("10.00"), quantity=1)
+
+    cart.tax()
+    cart.shipping()
+    assert _CountingTaxCalculator.call_count == 2
+    assert _CountingShippingCalculator.call_count == 2
+
+
+def test_discount_amount_is_cached_across_calls(cart, product):
+    """Cheap to compute (one Decimal multiplication) but still worth
+    caching: it runs inside ``total()`` and a template rendering
+    'you saved $X' alongside total shouldn't re-multiply per field."""
+    from cart.models import Discount, DiscountType
+
+    Discount.objects.create(
+        code="CACHE20",
+        discount_type=DiscountType.PERCENT,
+        value=Decimal("20.00"),
+    )
+    cart.add(product, Decimal("100.00"), quantity=2)
+    cart.apply_discount("CACHE20")
+
+    # Patch calculate_discount to count calls.
+    original = Discount.calculate_discount
+    Discount.calculate_discount.call_count = 0  # type: ignore[attr-defined]
+
+    def counting_calculate_discount(self, c):
+        counting_calculate_discount.call_count += 1  # type: ignore[attr-defined]
+        return original(self, c)
+
+    counting_calculate_discount.call_count = 0  # type: ignore[attr-defined]
+    Discount.calculate_discount = counting_calculate_discount  # type: ignore[method-assign]
+    try:
+        for _ in range(5):
+            cart.discount_amount()
+        assert counting_calculate_discount.call_count == 1  # type: ignore[attr-defined]
+    finally:
+        Discount.calculate_discount = original  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary

[`docs/ANALYSIS.md`](docs/ANALYSIS.md) §8.2 flagged this as the remaining caching gap: `summary()` and `count()` were already cached, but the four methods downstream of them recomputed every call. A template that renders subtotal + tax + shipping + discount + total invoked each configured calculator **up to 4× per render** — once for the standalone field, once inside `total()`.

## Fix

`tax()`, `shipping()`, `discount_amount()`, and `total()` now read from `self._cache` first and store the computed result before returning. `_invalidate_cache()` — called from every existing mutation — resets them alongside `summary()`/`count()`, so the cache stays correctly scoped to a single `Cart` instance between mutations.

Tax / shipping calculators in the wild frequently hit external APIs (Stripe Tax, Avalara, TaxJar). This cuts remote round-trips from N to 1 per request-level Cart.

## TDD

Five new tests using module-level counting calculators that increment a class attribute on each `calculate()` invocation:

| Test | Master | Branch |
|------|--------|--------|
| `test_tax_is_cached_across_calls` | 5 | **1** |
| `test_shipping_is_cached_across_calls` | 5 | **1** |
| `test_total_does_not_reinvoke_calculators_on_repeat_calls` | 4 + 4 | **1 + 1** |
| `test_add_invalidates_tax_and_shipping_caches` | 2 + 2 | **2 + 2** (cache clears on mutation — correct) |
| `test_discount_amount_is_cached_across_calls` | 5 | **1** |

## Test plan

- [x] `uv run pytest` → **343 passed** (338 → +5 new).
- [x] `uv run pytest --ds=tests.settings_custom_user tests/test_cart_custom_user.py` → **4 passed**.
- [x] `pre-commit run --all-files` → all 9 hooks clean (including mypy).

## Notes for reviewer

- No version bump — stays in `[Unreleased]`.
- Not breaking — additive caching under the hood; contract unchanged (same return values, same invalidation timing).
- No new settings. No new public methods.
- README "Money math" callout updated — the cache scope is now the full six methods (previously summary + count).
- Remaining candidates from ANALYSIS: mypy `strict = true` per-module tightening, dead exception cleanup (`ItemAlreadyExists` — defer for v4 bundle), currency field (v4 scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)